### PR TITLE
Remove Mime type based checks

### DIFF
--- a/clairmeta/dcp_check_pkl.py
+++ b/clairmeta/dcp_check_pkl.py
@@ -2,8 +2,6 @@
 # See LICENSE for more information
 
 import os
-import re
-import magic
 
 from clairmeta.utils.file import shaone_b64
 from clairmeta.dcp_check import CheckerBase, CheckException
@@ -53,27 +51,6 @@ class Checker(CheckerBase):
         # Note : dcp._list_asset is directly extracted from Assetmap
         if uuid not in self.dcp._list_asset.keys():
             raise CheckException("Not present in Assetmap")
-
-    # TODO : MIME Type might not be worth checking (too versatile)
-    # def check_assets_pkl_type(self, pkl, asset):
-    #     """ PKL assets MimeType check. """
-    #     _, path, asset = asset
-    #     mime_type = asset['Type']
-    #
-    #     if mime_type == "":
-    #         raise CheckException("Empty Type")
-    #     if not path or not os.path.exists(path):
-    #         return
-    #
-    #     mime_type = mime_type.split(';')[0]
-    #     mime_type = re.sub(r'x-\w+-', '', mime_type)
-    #     actual_type = magic.from_file(path, mime=True)
-    #     actual_type = re.sub(r'x-\w+-', '', actual_type)
-    #
-    #     if actual_type != mime_type:
-    #         raise CheckException(
-    #             "Mime Type mismatch, expected (from PKL) {} but found {}"
-    #             "".format(mime_type, actual_type))
 
     def check_assets_pkl_size(self, pkl, asset):
         """ PKL assets size check. """

--- a/clairmeta/dcp_check_subtitle.py
+++ b/clairmeta/dcp_check_subtitle.py
@@ -3,7 +3,6 @@
 
 import os
 import re
-import magic
 import pycountry
 
 from clairmeta.utils.time import tc_to_frame, frame_to_tc
@@ -294,25 +293,6 @@ class Checker(CheckerBase):
             raise CheckException(
                 "Subtitle font maximum size is {}, got {}".format(
                     human_size(font_max_size), human_size(font_size)))
-
-    def check_subtitle_cpl_font_format(self, playlist, asset, folder):
-        """ Subtitle font format validation. """
-        st_dict = self.get_subtitle_xml(asset, folder)
-        if not st_dict:
-            return
-        path, uri = self.get_font_path(st_dict, folder)
-        if not path:
-            return
-
-        font_format = magic.from_file(path, mime=True)
-        allowed_formats = DCP_SETTINGS['subtitle']['font_formats']
-
-        for f in allowed_formats:
-            if font_format in f:
-                return
-
-        raise CheckException("Subtitle font format not valid : {}".format(
-            font_format))
 
     # def check_subtitle_cpl_font_glyph(self, playlist, asset, folder):
     #     """ Check if font can render all glyphs (parsing the text used

--- a/clairmeta/dcp_check_utils.py
+++ b/clairmeta/dcp_check_utils.py
@@ -2,7 +2,6 @@
 # See LICENSE for more information
 
 import six
-import magic
 from datetime import datetime
 from dateutil import parser
 
@@ -20,13 +19,6 @@ def get_schema(name):
 
 
 def check_xml(xml_path, xml_ns, schema_type, schema_dcp):
-    # Correct file type (magic number)
-    xml_magic = magic.from_file(xml_path, mime=True)
-    if xml_magic != "text/xml":
-        raise CheckException(
-            "File type unknown, expected XML Document but got {}".format(
-                xml_magic))
-
     # Correct namespace
     schema_id = get_schema(xml_ns)
     if not schema_id:

--- a/clairmeta/settings.py
+++ b/clairmeta/settings.py
@@ -133,7 +133,6 @@ DCP_SETTINGS = {
     'subtitle': {
         # In bytes
         'font_max_size': 655360,
-        'font_formats': ['application/font-sfnt', 'application/x-font-ttf'],
     },
 }
 


### PR DESCRIPTION
The results of these checks depends on the platform and might not be relevant at all, better check the actual content.