### PR TITLE
Fix crash for empty xml files

### DIFF
--- a/clairmeta/dcp.py
+++ b/clairmeta/dcp.py
@@ -70,7 +70,7 @@ class DCP(object):
 
         for c in candidates:
             nodes = parse_xml(c, namespaces=DCP_SETTINGS['xmlns'])
-            if root_name in nodes:
+            if root_name and root_name in nodes:
                 xml_list.append(c)
 
         return xml_list


### PR DESCRIPTION
Crash on parsing DCP with empty XML files :

> \<?xml version="1.0" encoding="UTF-8" standalone="no"?>