### PR TITLE
Update MainSubtitle / MainPicture Duration check

### DIFF
--- a/clairmeta/profile.py
+++ b/clairmeta/profile.py
@@ -18,7 +18,6 @@ DCP_CHECK_PROFILE = {
         'check_dcp_foreign_files': 'WARNING',
         'check_cpl_contenttitle_annotationtext_match': 'WARNING',
         'check_cpl_contenttitle_pklannotationtext_match': 'WARNING',
-        'check_cpl_reel_duration_picture_subtitles': 'WARNING',
         'check_assets_cpl_missing_from_vf': 'WARNING',
         'check_assets_cpl_labels_schema': 'WARNING',
         'check_certif_multi_role': 'WARNING',


### PR DESCRIPTION
New rules :
*  Interop: MainSubtitle Duration must be equal to MainPicture Duration.
*  SMPTE: MainSubtitle duration is allowed to be less than or equal to MainPicture Duration.

This check is now an error.