### PR TITLE
Add apt support for Ubuntu 18.04 bionic and dropping 17.04 artful

### DIFF
--- a/.travis/Dockerfile-build-artful
+++ b/.travis/Dockerfile-build-artful
@@ -1,0 +1,44 @@
+FROM ubuntu:bionic
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    dput \
+    curl \
+    wget \
+    libxml2-dev \
+    build-essential \
+    devscripts \
+    fakeroot \
+    make \
+    gcc \
+    locales \
+    debhelper \
+    python \
+    python-dev \
+    python-pip \
+    python-all \
+    python-setuptools \
+    python-all-dev \
+    python3 \
+    python3-dev \
+    python3-pip \
+    python3-all \
+    python3-setuptools \
+    python3-all-dev
+
+RUN dpkg-reconfigure locales && \
+    locale-gen en_US.UTF-8 && \
+    /usr/sbin/update-locale LANG=en_US.UTF-8
+
+RUN apt-get update && apt-get install -y \
+    apt-transport-https \
+    libffi-dev \
+    autotools-dev \
+    libssl-dev \
+    lintian
+
+RUN pip3 install -U pip setuptools
+
+ENV LC_ALL en_US.UTF-8
+
+CMD cd /build_src && ./build_deb.sh

--- a/.travis/Dockerfile-build-bionic
+++ b/.travis/Dockerfile-build-bionic
@@ -1,4 +1,4 @@
-FROM ubuntu:artful
+FROM ubuntu:bionic
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     git \

--- a/.travis/Dockerfile-install-artful
+++ b/.travis/Dockerfile-install-artful
@@ -1,0 +1,13 @@
+FROM ubuntu:bionic
+
+RUN apt-get update && apt-get install -y apt-transport-https
+
+ENV DCP="/dcp/ECL-SINGLE-CPL_TST_S_EN-EN_UK-U_51_2K_DI_20160622_ECL_SMPTE_VF/"
+
+CMD apt-get install dirmngr \
+ && gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv 379CE192D401AB61 \
+ && gpg --export --armor 379CE192D401AB61 | apt-key add - \
+ && echo "deb https://dl.bintray.com/ymagis/Clairmeta bionic main" | tee /etc/apt/sources.list.d/clairmeta.list \
+ && apt-get update \
+ && apt-get install -y python3-clairmeta \
+ && python3.6 -m clairmeta.cli check -type dcp ${DCP}

--- a/.travis/Dockerfile-install-bionic
+++ b/.travis/Dockerfile-install-bionic
@@ -1,4 +1,4 @@
-FROM ubuntu:artful
+FROM ubuntu:bionic
 
 RUN apt-get update && apt-get install -y apt-transport-https
 
@@ -7,7 +7,7 @@ ENV DCP="/dcp/ECL-SINGLE-CPL_TST_S_EN-EN_UK-U_51_2K_DI_20160622_ECL_SMPTE_VF/"
 CMD apt-get install dirmngr \
  && gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv 379CE192D401AB61 \
  && gpg --export --armor 379CE192D401AB61 | apt-key add - \
- && echo "deb https://dl.bintray.com/ymagis/Clairmeta artful main" | tee /etc/apt/sources.list.d/clairmeta.list \
+ && echo "deb https://dl.bintray.com/ymagis/Clairmeta bionic main" | tee /etc/apt/sources.list.d/clairmeta.list \
  && apt-get update \
  && apt-get install -y python3-clairmeta \
  && python3.6 -m clairmeta.cli check -type dcp ${DCP}

--- a/.travis/build_env.sh
+++ b/.travis/build_env.sh
@@ -20,12 +20,12 @@ docker run -it \
   -e "DISTRIBUTION=xenial" \
   clairmeta/build_xenial
 
-docker build -f .travis/Dockerfile-build-artful -t clairmeta/build_artful .
+docker build -f .travis/Dockerfile-build-bionic -t clairmeta/build_bionic .
 docker run -it \
   -v $PWD/.travis:/build_src \
   -e "BINTRAY_USER=${BINTRAY_USER}" \
   -e "BINTRAY_ORG=${BINTRAY_ORG}" \
   -e "BINTRAY_REPO=${BINTRAY_REPO}" \
   -e "BINTRAY_TOKEN=${BINTRAY_TOKEN}" \
-  -e "DISTRIBUTION=artful" \
-  clairmeta/build_artful
+  -e "DISTRIBUTION=bionic" \
+  clairmeta/build_bionic

--- a/.travis/build_env.sh
+++ b/.travis/build_env.sh
@@ -20,6 +20,16 @@ docker run -it \
   -e "DISTRIBUTION=xenial" \
   clairmeta/build_xenial
 
+docker build -f .travis/Dockerfile-build-artful -t clairmeta/build_artful .
+docker run -it \
+  -v $PWD/.travis:/build_src \
+  -e "BINTRAY_USER=${BINTRAY_USER}" \
+  -e "BINTRAY_ORG=${BINTRAY_ORG}" \
+  -e "BINTRAY_REPO=${BINTRAY_REPO}" \
+  -e "BINTRAY_TOKEN=${BINTRAY_TOKEN}" \
+  -e "DISTRIBUTION=artful" \
+clairmeta/build_artful
+
 docker build -f .travis/Dockerfile-build-bionic -t clairmeta/build_bionic .
 docker run -it \
   -v $PWD/.travis:/build_src \

--- a/README.rst
+++ b/README.rst
@@ -75,6 +75,7 @@ Install from Debian package (all requirements will be automatically installed):
     # Replace <distro> appropriately
     # Ubuntu 14.04 : use trusty
     # Ubuntu 16.04 : use xenial
+    # Ubuntu 17.04 : use artful
     # Ubuntu 18.04 : use bionic
     echo "deb https://dl.bintray.com/ymagis/Clairmeta <distro> main" | sudo tee /etc/apt/sources.list.d/clairmeta.list
 

--- a/README.rst
+++ b/README.rst
@@ -75,7 +75,7 @@ Install from Debian package (all requirements will be automatically installed):
     # Replace <distro> appropriately
     # Ubuntu 14.04 : use trusty
     # Ubuntu 16.04 : use xenial
-    # Ubuntu 17.04 : use artful
+    # Ubuntu 18.04 : use bionic
     echo "deb https://dl.bintray.com/ymagis/Clairmeta <distro> main" | sudo tee /etc/apt/sources.list.d/clairmeta.list
 
     sudo apt-get update


### PR DESCRIPTION
Ubuntu 17.04 artful [is end of file]( http://fridge.ubuntu.com/2018/07/19/ubuntu-17-10-artful-aardvark-end-of-life-reached-on-july-19-2018/), switching to [18.04 bionic](https://wiki.ubuntu.com/BionicBeaver/ReleaseNotes).

Or should we keep the artful variant, for now, so we don't break anything for current users?