### PR TITLE
Use the ceiling of frame fractions when converting subtitle time code to frames.

### DIFF
--- a/clairmeta/dcp_check_subtitle.py
+++ b/clairmeta/dcp_check_subtitle.py
@@ -60,7 +60,10 @@ class SubtitleUtils(object):
     def ticks_to_frame(self, tick, edit_rate):
         tick = int(tick)
         time_base = 1.0 / edit_rate
-        return int((tick * 0.004) // time_base)
+
+        # Ceiling division. Ugly, but avoids importing math.ceil
+        # https://stackoverflow.com/questions/14822184/is-there-a-ceiling-equivalent-of-operator-in-python#17511341
+        return int(-(-(tick * 0.004) // time_base))
 
     def st_tc_frames(self, tc, edit_rate):
         """ Convert TimeCode to frame count.


### PR DESCRIPTION
I have a Interop subtitle XML with this line:

``<Subtitle SpotNumber="1" FadeUpTime="20" FadeDownTime="20" TimeIn="00:00:00:000" TimeOut="00:00:00:010">``

Before this patch I get the error "Subtitle 1 null or negative duration" from check_subtitle_cpl_st_timing(). This is because the duration is rounded to 0 by floor division in ticks_to_frame().

10 ticks at 24 fps evaluates to 0.96 frames in floating point. Since a subtitle can not be displayed for a fraction of a frame it makes sense to always round up to the next whole frame.