### PR TITLE
Bypass naming convention versus. essence check for burned subtitles

### DIFF
--- a/clairmeta/dcp_check_isdcf_dcnc.py
+++ b/clairmeta/dcp_check_isdcf_dcnc.py
@@ -114,8 +114,9 @@ class Checker(CheckerBase):
         """ Subtitle (presence) from CPL and ContentTitleText shall match. """
         cpl_node = playlist['Info']['CompositionPlaylist']
 
-        subtitle = fields['Language'].get('Subtitle')
-        if subtitle != cpl_node['Subtitle']:
+        hasSub = fields['Language'].get('Subtitle', False)
+        hasBurnedSub = fields['Language'].get('BurnedSubtitle', False)
+        if not hasBurnedSub and hasSub != cpl_node['Subtitle']:
             raise CheckException(
                 "ContentTitle suggest Subtitle but CPL have none")
 


### PR DESCRIPTION
This fix issue in #59 