### PR TITLE
File sequence scan improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ clairmeta.egg-info
 __pycache__
 .pybuild
 .coverage
+.mypy_cache/
+.vscode/

--- a/Pipfile
+++ b/Pipfile
@@ -1,18 +1,14 @@
 [[source]]
-
 url = "https://pypi.python.org/simple"
 verify_ssl = true
 name = "pypi"
 
-
 [dev-packages]
-
 coverage = "*"
 nose = "*"
-
+pep8 = "*"
 
 [packages]
-
 lxml = "*"
 dicttoxml = "*"
 xmltodict = "*"

--- a/clairmeta/sequence.py
+++ b/clairmeta/sequence.py
@@ -47,8 +47,9 @@ class Sequence(object):
             setting['directory_white_list']
         )
 
-        for folder, exts in six.iteritems(self.probe_folder):
-            for ext, keys in six.iteritems(exts):
+        for folder, seqs in six.iteritems(self.probe_folder):
+            for seq, keys in six.iteritems(seqs):
+                ext = keys.get('Extension')
                 check_keys = setting['allowed_extensions'].get('.' + ext)
                 probe_keys = keys.get('Probe')
 

--- a/clairmeta/sequence_check.py
+++ b/clairmeta/sequence_check.py
@@ -2,9 +2,9 @@
 # See LICENSE for more information
 
 import os
-import re
 
 from clairmeta.utils.sys import number_is_close
+from clairmeta.utils.file import parse_name
 
 
 def check_sequence(path, allowed_extensions, ignore_files=[], ignore_dirs=[]):
@@ -105,49 +105,3 @@ def check_sequence_folder(dirpath, filenames, allowed_extensions):
         if idx != fno:
             raise ValueError(
                 'File sequence jump found, file {} not found'.format(idx))
-
-
-IMAGENO_REGEX = re.compile(r'[\._]?(?P<Index>\d+)(?=[\._])')
-
-
-def parse_name(filename, regex=IMAGENO_REGEX):
-    """ Extract image name and index from filename.
-
-        Args:
-            filename (str): Image file name.
-            regex (RegexObject): Extraction rule.
-
-        Returns:
-            Tuple (name, index) extracted from filename.
-
-        Raises:
-            ValueError: If image index not found in ``filename``.
-
-        >>> parse_name('myfile.0001.tiff')
-        ('myfile', 1)
-        >>> parse_name('myfile_0001.tiff')
-        ('myfile', 1)
-        >>> parse_name('myfile.123.0001.tiff')
-        ('myfile.123', 1)
-        >>> parse_name('00123060.tiff')
-        ('', 123060)
-        >>> parse_name('123060.tiff')
-        ('', 123060)
-        >>> parse_name('myfile.tiff')
-        Traceback (most recent call last):
-        ...
-        ValueError: myfile.tiff : image index not found
-        >>> parse_name('myfile.abcdef.tiff')
-        Traceback (most recent call last):
-        ...
-        ValueError: myfile.abcdef.tiff : image index not found
-
-    """
-    m = list(regex.finditer(filename))
-    if m == []:
-        raise ValueError('{} : image index not found'.format(filename))
-
-    lastm = m[-1]
-    name = filename[:lastm.start()]
-    index = lastm.groupdict()['Index']
-    return name, int(index)

--- a/clairmeta/sequence_check.py
+++ b/clairmeta/sequence_check.py
@@ -7,7 +7,7 @@ from clairmeta.utils.sys import number_is_close
 from clairmeta.utils.file import parse_name
 
 
-def check_sequence(path, allowed_extensions, ignore_files=[], ignore_dirs=[]):
+def check_sequence(path, allowed_extensions, ignore_files=None, ignore_dirs=None):
     """ Check image file sequence coherence recursively.
 
         Args:

--- a/clairmeta/utils/file.py
+++ b/clairmeta/utils/file.py
@@ -11,6 +11,7 @@ import tempfile
 import base64
 import hashlib
 import time
+import re
 
 
 def folder_size(folder):
@@ -161,3 +162,49 @@ def shaone_b64(file_path, callback=None):
     # Encode base64 and remove carriage return
     sha1b64 = base64.b64encode(sha1.digest())
     return sha1b64.decode("utf-8")
+
+
+IMAGENO_REGEX = re.compile(r'[\._]?(?P<Index>\d+)(?=[\._])')
+
+
+def parse_name(filename, regex=IMAGENO_REGEX):
+    """ Extract image name and index from filename.
+
+        Args:
+            filename (str): Image file name.
+            regex (RegexObject): Extraction rule.
+
+        Returns:
+            Tuple (name, index) extracted from filename.
+
+        Raises:
+            ValueError: If image index not found in ``filename``.
+
+        >>> parse_name('myfile.0001.tiff')
+        ('myfile', 1)
+        >>> parse_name('myfile_0001.tiff')
+        ('myfile', 1)
+        >>> parse_name('myfile.123.0001.tiff')
+        ('myfile.123', 1)
+        >>> parse_name('00123060.tiff')
+        ('', 123060)
+        >>> parse_name('123060.tiff')
+        ('', 123060)
+        >>> parse_name('myfile.tiff')
+        Traceback (most recent call last):
+        ...
+        ValueError: myfile.tiff : image index not found
+        >>> parse_name('myfile.abcdef.tiff')
+        Traceback (most recent call last):
+        ...
+        ValueError: myfile.abcdef.tiff : image index not found
+
+    """
+    m = list(regex.finditer(filename))
+    if m == []:
+        raise ValueError('{} : image index not found'.format(filename))
+
+    lastm = m[-1]
+    name = filename[:lastm.start()]
+    index = lastm.groupdict()['Index']
+    return name, int(index)


### PR DESCRIPTION
File sequence probe now only store [start, end] index and count of elements instead of file path list.

Fix #77 