### PR TITLE
Improve assets path metadata consistency

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -10,6 +10,7 @@ Kieran O'Leary
 Laureen Gautier
 Laurent Bodson
 Leo Winter
+Maxime Huynh
 Nelsy Zami
 Quentin Bisserie
 Rémi Achard

--- a/README.rst
+++ b/README.rst
@@ -152,7 +152,7 @@ Custom profile check :
 ::
 
     from clairmeta import DCP
-    from clairmeta.profile include load_profile
+    from clairmeta.profile import load_profile
 
     dcp = DCP("path/to/dcp")
     profile = load_profile("/path/to/profile.json")

--- a/clairmeta/dcp.py
+++ b/clairmeta/dcp.py
@@ -165,8 +165,13 @@ class DCP(object):
         for cpl in self._list_cpl:
             for _, asset in list_cpl_assets(cpl):
                 asset_id = asset['Id']
+                asset['Path'] = ''
+                asset['AbsolutePath'] = ''
+
                 if asset_id in self._list_asset:
                     asset['Path'] = self._list_asset[asset_id]
+                    asset['AbsolutePath'] = os.path.join(
+                        self.path, self._list_asset[asset_id])
                 else:
                     self.package_type = 'VF'
 
@@ -174,7 +179,7 @@ class DCP(object):
         """ Probe mxf assets for each reel. """
         for cpl in self._list_cpl:
             for essence, asset in list_cpl_assets(cpl):
-                asset_path = os.path.join(self.path, asset.get('Path', ''))
+                asset_path = asset.get('AbsolutePath', '')
                 cpl_probe_asset(asset, essence, asset_path)
 
     def cpl_parse_metadata(self):

--- a/clairmeta/dcp_check.py
+++ b/clairmeta/dcp_check.py
@@ -186,7 +186,7 @@ class DCPChecker(CheckerBase):
         """ VF package shall reference assets present in OV. """
         ov_dcp_dict = self.ov_dcp.parse()
 
-        if 'Path' not in asset:
+        if not asset.get('Path'):
             uuid = asset['Id']
             path_ov = ov_dcp_dict['asset_list'].get(uuid)
 
@@ -201,5 +201,5 @@ class DCPChecker(CheckerBase):
                     "".format(essence, path_ov))
 
             # Probe asset for later checks
-            asset['Path'] = asset_path
+            asset['AbsolutePath'] = asset_path
             cpl_probe_asset(asset, essence, asset_path)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -62,7 +62,11 @@ class CliTest(unittest.TestCase):
         json_test = json.loads(msg, object_pairs_hook=OrderedDict)
         with open(self.get_file_path('ECL01.json')) as f:
             json_gold = json.load(f, object_pairs_hook=OrderedDict)
-        self.assertEqual(json_test, json_gold)
+
+        # Prefer comparing strings for better diagnostic messages
+        self.assertEqual(
+            json.dumps(json_test, indent=4, sort_keys=True),
+            json.dumps(json_gold, indent=4, sort_keys=True))
 
     def test_dcp_check_good(self):
         status, msg = self.launch_command([


### PR DESCRIPTION
In this Pull Request :
*  Fix a minor typo in the Readme code samples.
*  Improve consistence for asset path metadata in the CompositionPlaylist/ReelList/Assets dictionary.

`Path` is the relative path available for internal assets and empty for external assets, `AbsolutePath` is the absolute path available for internal assets and for external assets (only if a `dcp.check(ov_path="/my/ov")` is performed, see below)

```
from clairmeta import DCP

dcp = DCP("/my/dcp/version_file")
dcp.check(ov_path="/my/dcp/original_version")

# `Path` non-empty for VF assets
# `AbsolutePath` available for both VF and correctly relinked OV assets
metadata = dcp.parse()
```