### PR TITLE
UUID case insensitive checks

### DIFF
--- a/clairmeta/dcp_check_atmos.py
+++ b/clairmeta/dcp_check_atmos.py
@@ -33,9 +33,19 @@ class Checker(CheckerBase):
         mxf_ul = asset['Probe'].get('DataEssenceCoding', '')
 
         if not cpl_ul:
-            raise CheckException("Missing DataType tag for Atmos Track")
-        elif not mxf_ul or cpl_ul != mxf_ul:
-            raise CheckException("Invalid Atmos Essence")
+            raise CheckException("Missing Atmos DataType tag (CPL/AuxData")
+        elif not mxf_ul:
+            raise CheckException("Missing Atmos Essence Coding UL (MXF)")
+
+        cpl_ul, mxf_ul = cpl_ul.lower(), mxf_ul.lower()
+        if cpl_ul != mxf_ul:
+            raise CheckException(
+                "Incoherent Atmos Data Essence Coding, CPL {} / MXF {}"
+                .format(cpl_ul, mxf_ul))
+        elif mxf_ul != ul:
+            raise CheckException(
+                "Unknown Atmos Data Essence Coding, expecting {} but got {}"
+                .format(ul, mxf_ul))
 
     def check_atmos_cpl_channels(self, playlist, asset):
         """ Atmos maximum channels count.

--- a/clairmeta/dcp_check_cpl.py
+++ b/clairmeta/dcp_check_cpl.py
@@ -262,7 +262,9 @@ class Checker(CheckerBase):
 
         if not is_found:
             asset_type = get_type_for_asset(playlist, uuid)
-            raise CheckException("Asset missing, multi CPL must be complete")
+            raise CheckException(
+                "Asset missing ({}), multi CPL must be complete".format(
+                    asset_type))
 
     def check_assets_cpl_labels(self, playlist, asset):
         """ CPL assets labels check. """

--- a/clairmeta/dcp_check_subtitle.py
+++ b/clairmeta/dcp_check_subtitle.py
@@ -444,22 +444,22 @@ class Checker(CheckerBase):
         if not st_dict:
             return
 
-        st_uuid = self.st_util.get_subtitle_uuid(st_dict)
+        st_uuid = self.st_util.get_subtitle_uuid(st_dict).lower()
         _, asset = asset
 
         if self.dcp.schema == 'Interop':
-            cpl_uuid = asset['Id']
+            cpl_uuid = asset['Id'].lower()
             if st_uuid != cpl_uuid:
                 raise CheckException(
-                    "Subtitle UUID mismatch, Subtitle claims {} but CPL "
-                    "{}".format(st_uuid, cpl_uuid))
-            folder_name = os.path.basename(folder)
+                    "Subtitle UUID mismatch, Subtitle claims {} but CPL {}"
+                    .format(st_uuid, cpl_uuid))
+            folder_name = os.path.basename(folder).lower()
             if st_uuid not in folder_name:
                 raise CheckException(
                     "Subtitle directory name unexpected, should contain {} but"
                     " got {}".format(st_uuid, folder_name))
         elif self.dcp.schema == 'SMPTE':
-            resource_uuid = asset['Probe'].get('AssetID', "")
+            resource_uuid = asset['Probe'].get('AssetID', "").lower()
             if resource_uuid != st_uuid:
                 raise CheckException(
                     "Subtitle UUID mismatch, Subtitle claims {} but MXF "

--- a/clairmeta/dcp_check_subtitle.py
+++ b/clairmeta/dcp_check_subtitle.py
@@ -465,6 +465,28 @@ class Checker(CheckerBase):
                     "Subtitle UUID mismatch, Subtitle claims {} but MXF "
                     "{}".format(st_uuid, resource_uuid))
 
+    def check_subtitle_cpl_uuid_case(self, playlist, asset, folder):
+        """ Subtitle UUID case mismatch. """
+        st_dict = self.st_util.get_subtitle_xml(asset, folder)
+        if not st_dict:
+            return
+
+        st_uuid = self.st_util.get_subtitle_uuid(st_dict)
+        _, asset = asset
+
+        if self.dcp.schema == 'Interop':
+            cpl_uuid = asset['Id']
+            if st_uuid != cpl_uuid and st_uuid.lower() == cpl_uuid.lower():
+                raise CheckException(
+                    "Subtitle UUID case mismatch, Subtitle {} - CPL {}".format(
+                        st_uuid, cpl_uuid))
+            folder_name = os.path.basename(folder)
+            if (st_uuid not in folder_name
+               and st_uuid.lower() in folder_name.lower()):
+                raise CheckException(
+                    "Subtitle directory name case mismatch, Folder {} - CPL {}"
+                    .format(st_uuid, folder_name))
+
     def check_subtitle_cpl_duplicated_uuid(self, playlist, asset, folder):
         """ Issue when using the same UUID for Subtitle XML and MXF.
 

--- a/clairmeta/dcp_check_utils.py
+++ b/clairmeta/dcp_check_utils.py
@@ -57,6 +57,6 @@ def compare_uuid(uuid_to_check, uuid_reference):
     if not check_uuid(uuid):
         raise CheckException("Invalid {} uuid found : {}".format(
             name, uuid))
-    if uuid != uuid_ref:
+    if uuid.lower() != uuid_ref.lower():
         raise CheckException("Uuid {} ({}) not equal to {} ({})".format(
             name, uuid, name_ref, uuid_ref))

--- a/clairmeta/profile.py
+++ b/clairmeta/profile.py
@@ -30,6 +30,7 @@ DCP_CHECK_PROFILE = {
         'check_picture_cpl_resolution': 'WARNING',
         'check_subtitle_cpl_reel_number': 'WARNING',
         'check_subtitle_cpl_empty': 'WARNING',
+        'check_subtitle_cpl_uuid_case': 'WARNING',
         'check_subtitle_cpl_duplicated_uuid': 'WARNING',
         'check_picture_cpl_archival_framerate': 'WARNING',
         'check_picture_cpl_hfr_framerate': 'WARNING',


### PR DESCRIPTION
Ignore various UUID / UL case mismatch :
*  Subtitle / Folder (for Interop) vs. CPL UUID comparison. 
    Previously we returned an error in this case, now only a warning.
*  Atmos Essence Coding UL, CPL / MXF comparison
    Silently succeed

Feedback much welcome on this subject !