### PR TITLE
Fix mediainfo bitdepth

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,1 @@
+comment: false

--- a/clairmeta/sequence.py
+++ b/clairmeta/sequence.py
@@ -70,9 +70,6 @@ class Sequence(object):
         for key, expect_val in six.iteritems(check_keys):
             val = key_by_path_dict(probe_keys, key)
 
-            if key == 'ProbeImage.BitDepth' and ' bits' in val:
-                expect_val += ' bits'
-
             if isinstance(expect_val, list):
                 if val not in expect_val:
                     raise ValueError("{} - Invalid {}, got {} but expected"

--- a/clairmeta/utils/probe.py
+++ b/clairmeta/utils/probe.py
@@ -343,6 +343,11 @@ def probe_mediainfo(path):
             track_type = track.pop('@type')
             track = transform_keys_dict(track, camelize)
 
+            # Mediainfo 0.7
+            bitdepth = track.get('BitDepth')
+            if bitdepth and ' bits' in bitdepth and track_type == 'Image':
+                track['BitDepth'] = bitdepth.split()[0]
+
             if track_type == 'General':
                 metadata = track
             else:


### PR DESCRIPTION
Hey @nikicpetar,

I propose this update, that is basically moving your fix to the probe module. I did this because there is already code that deals with difference in mediainfo output depending on the version. I feel it's easier to manage this way.

Does that feel right to you ? I test on ubuntu 18.04 and mediainfo 0.7.62 and it seemed alright but I'll wait for your approval.

Note that I did the `split()` thing because on my test, mediainfo was actually returning `16 bits / 16 bits / 16 bits` !