### PR TITLE
Improve console report formating

### DIFF
--- a/clairmeta/dcp_check.py
+++ b/clairmeta/dcp_check.py
@@ -141,8 +141,7 @@ class DCPChecker(CheckerBase):
             for a in self.dcp._list_files
             if a not in list_asset_path]
         if self.dcp.foreign_files:
-            raise CheckException("Foreign files detected\n{}".format(
-                '\n'.join(self.dcp.foreign_files)))
+            raise CheckException('\n'.join(self.dcp.foreign_files))
 
     def check_dcp_multiple_am_or_vol(self):
         """ Only one AssetMap and VolIndex shall be present.

--- a/clairmeta/dcp_check.py
+++ b/clairmeta/dcp_check.py
@@ -30,7 +30,7 @@ class DCPChecker(CheckerBase):
         """
         super(DCPChecker, self).__init__(dcp, profile)
         self.ov_path = ov_path
-
+        self.ov_dcp = None
         self.hash_callback = hash_callback
         if self.hash_callback and inspect.isclass(self.hash_callback):
             self.hash_callback = hash_callback(self.dcp.size)
@@ -164,10 +164,12 @@ class DCPChecker(CheckerBase):
         if not self.ov_path:
             return
 
-        self.run_check(self.check_link_ov_coherence)
+        self.run_check(self.check_link_ov_coherence, stack=[self.dcp.path])
         for cpl in self.dcp._list_cpl:
             for essence, asset in list_cpl_assets(cpl):
-                self.run_check(self.check_link_ov_asset, asset, essence)
+                self.run_check(
+                    self.check_link_ov_asset,
+                    asset, essence, stack=[self.dcp.path])
 
     def check_dcp_signed(self):
         """ DCP with encrypted content must be digitally signed.
@@ -207,6 +209,9 @@ class DCPChecker(CheckerBase):
 
             Reference : N/A
         """
+        if not self.ov_dcp:
+            return
+
         ov_dcp_dict = self.ov_dcp.parse()
 
         if not asset.get('Path'):

--- a/clairmeta/dcp_check.py
+++ b/clairmeta/dcp_check.py
@@ -141,8 +141,8 @@ class DCPChecker(CheckerBase):
             for a in self.dcp._list_files
             if a not in list_asset_path]
         if self.dcp.foreign_files:
-            raise CheckException("Foreign files detected : {}".format(
-                self.dcp.foreign_files))
+            raise CheckException("Foreign files detected\n{}".format(
+                '\n'.join(self.dcp.foreign_files)))
 
     def check_dcp_multiple_am_or_vol(self):
         """ Only one AssetMap and VolIndex shall be present.

--- a/clairmeta/dcp_check.py
+++ b/clairmeta/dcp_check.py
@@ -88,7 +88,7 @@ class DCPChecker(CheckerBase):
 
         # Run own tests
         dcp_checks = self.find_check('dcp')
-        [self.run_check(c) for c in dcp_checks]
+        [self.run_check(c, stack=[self.dcp.path]) for c in dcp_checks]
         self.setup_dcp_link_ov()
 
         # Run external modules tests

--- a/clairmeta/dcp_check_am.py
+++ b/clairmeta/dcp_check_am.py
@@ -15,15 +15,16 @@ class Checker(CheckerBase):
 
     def run_checks(self):
         for source in self.dcp._list_am:
+            asset_stack = [source['FileName']]
+
             checks = self.find_check('am')
-            [self.run_check(check, source, message=source['FileName'])
+            [self.run_check(check, source, stack=asset_stack)
              for check in checks]
 
             asset_checks = self.find_check('assets_am')
             [self.run_check(
-                check, source, asset, message="{} (Asset {})".format(
-                    source['FileName'],
-                    asset[2]['ChunkList']['Chunk']['Path']))
+                check, source, asset,
+                stack=asset_stack + [asset[2]['ChunkList']['Chunk']['Path']])
              for asset in list_am_assets(source)
              for check in asset_checks]
 

--- a/clairmeta/dcp_check_atmos.py
+++ b/clairmeta/dcp_check_atmos.py
@@ -13,11 +13,11 @@ class Checker(CheckerBase):
 
     def run_checks(self):
         for source in self.dcp._list_cpl:
-
             asset_checks = self.find_check('atmos_cpl')
-            [self.run_check(
-                check, source, asset, message="{} (Asset {})".format(
-                    source['FileName'], asset[1].get('Path', asset[1]['Id'])))
+            [self.run_check(check, source, asset,
+             stack=[
+                 source['FileName'],
+                 asset[1].get('Path') or asset[1]['Id']])
              for asset in list_cpl_assets(
                 source, filters='AuxData', required_keys=['Probe'])
              if asset[1]['Schema'] == 'Atmos'

--- a/clairmeta/dcp_check_base.py
+++ b/clairmeta/dcp_check_base.py
@@ -240,11 +240,7 @@ class CheckerBase(object):
         ind = indent_offset + indent_level
 
         filename = key
-        desc = ""
-        for cpl in self.dcp._list_cpl:
-            if cpl['FileName'] == filename:
-                desc = "({})".format(
-                    cpl['Info']['CompositionPlaylist']['ContentTitleText'])
+        desc = self.title_from_filename(filename)
         messages = values.pop('messages', [])
 
         out_str = '' if indent_level == 0 else '\n'
@@ -265,6 +261,23 @@ class CheckerBase(object):
                 out_str, k, v, indent_level + indent_step)
 
         return out_str
+
+    def title_from_filename(self, filename):
+        """ Returns a human friendly title for the given file. """
+        for cpl in self.dcp._list_cpl:
+            if cpl['FileName'] == filename:
+                desc = "({})".format(
+                    cpl['Info']['CompositionPlaylist'].get(
+                        'ContentTitleText', ''))
+                return desc
+
+        for pkl in self.dcp._list_pkl:
+            if pkl['FileName'] == filename:
+                desc = "({})".format(
+                    pkl['Info']['PackingList'].get('AnnotationText', ''))
+                return desc
+
+        return ''
 
     def get_valid(self):
         """ Check status is valid. """

--- a/clairmeta/dcp_check_base.py
+++ b/clairmeta/dcp_check_base.py
@@ -190,7 +190,8 @@ class CheckerBase(object):
                     node[filename] = {}
 
                 node = node[filename]
-                node['messages'] = []
+                if 'messages' not in node:
+                    node['messages'] = []
 
             node['messages'] += [c.msg]
 

--- a/clairmeta/dcp_check_base.py
+++ b/clairmeta/dcp_check_base.py
@@ -137,7 +137,7 @@ class CheckerBase(object):
             check_exec.criticality = "ERROR"
             self.check_log.error(check_exec.msg)
         finally:
-            check_exec.asset_stack = kwargs.get('stack', [])
+            check_exec.asset_stack = kwargs.get('stack', [self.dcp.path])
             check_exec.seconds_elapsed = time.time() - start
             self.check_executions.append(check_exec)
             return check_exec.valid, check_res

--- a/clairmeta/dcp_check_base.py
+++ b/clairmeta/dcp_check_base.py
@@ -18,8 +18,10 @@ class CheckException(Exception):
 
 class CheckExecution(object):
     """ Check execution with status and time elapsed. """
+
     def __init__(self, name):
         self.name = name
+        self.doc = ""
         self.message = ""
         self.valid = False
         self.seconds_elapsed = 0
@@ -115,6 +117,7 @@ class CheckerBase(object):
         start = time.time()
         name, func = check.__name__, check
         check_exec = CheckExecution(name)
+        check_exec.doc = check.__doc__
         check_res = None
 
         try:
@@ -193,7 +196,9 @@ class CheckerBase(object):
                 if 'messages' not in node:
                     node['messages'] = []
 
-            node['messages'] += [c.msg]
+            docstring_lines = c.doc.split('\n')
+            desc = docstring_lines[0] if docstring_lines else c.name
+            node['messages'] += ['.' + desc + '\n' + c.msg]
 
         self.check_log.info("DCP : {}".format(self.dcp.path))
         self.check_log.info("Size : {}".format(human_size(self.dcp.size)))
@@ -243,8 +248,7 @@ class CheckerBase(object):
         messages = values.pop('messages', [])
 
         out_str = '' if indent_level == 0 else '\n'
-        out_str += indent_char * ind
-        out_str += '+ ' if indent_level == 0 else '- '
+        out_str += indent_char * ind + '+ '
         out_str += filename
         out_str += ' ' + desc if desc else ''
 
@@ -253,7 +257,7 @@ class CheckerBase(object):
             out_str += "\n"
             out_str += indent_char * ind
             # Correct indentation for multi-lines messages
-            out_str += ("\n" + indent_char * (ind + 1)).join(m.split("\n"))
+            out_str += ("\n" + indent_char * (ind + 2)).join(m.split("\n"))
         ind -= indent_step
 
         for k, v in six.iteritems(values):

--- a/clairmeta/dcp_check_cpl.py
+++ b/clairmeta/dcp_check_cpl.py
@@ -24,14 +24,16 @@ class Checker(CheckerBase):
 
     def run_checks(self):
         for source in self.dcp._list_cpl:
+            asset_stack = [source['FileName']]
+
             checks = self.find_check('cpl')
-            [self.run_check(check, source, message=source['FileName'])
+            [self.run_check(check, source, stack=asset_stack)
              for check in checks]
 
             asset_checks = self.find_check('assets_cpl')
-            [self.run_check(
-                check, source, asset, message="{} (Asset {})".format(
-                    source['FileName'], asset[1].get('Path', asset[1]['Id'])))
+            [self.run_check(check, source, asset,
+             stack=asset_stack + [
+                 asset[1].get('Path') or asset[1]['Id']])
              for asset in list_cpl_assets(source)
              for check in asset_checks]
 

--- a/clairmeta/dcp_check_isdcf_dcnc.py
+++ b/clairmeta/dcp_check_isdcf_dcnc.py
@@ -34,7 +34,7 @@ class Checker(CheckerBase):
         ct = cpl_node['ContentTitleText']
         self.fields, errors = parse_isdcf_string(ct)
         if errors:
-            raise CheckException('\n\t\t' + '\n\t\t'.join(errors))
+            raise CheckException('ISDCF naming convention\n' + '\n'.join(errors))
 
     def check_dcnc_field_redband(self, playlist, fields):
         """ RedBand qualifier is restricted to Trailer. """

--- a/clairmeta/dcp_check_isdcf_dcnc.py
+++ b/clairmeta/dcp_check_isdcf_dcnc.py
@@ -16,14 +16,12 @@ class Checker(CheckerBase):
 
     def run_checks(self):
         for source in self.dcp._list_cpl:
-            msg_prefix = "{} ({})".format(
-                source['Info']['CompositionPlaylist']['ContentTitleText'],
-                source['FileName'])
+            asset_stack = [source['FileName']]
             self.run_check(
-                self.check_dcnc_compliance, source, message=msg_prefix)
+                self.check_dcnc_compliance, source, stack=asset_stack)
 
             checks = self.find_check('dcnc_field')
-            [self.run_check(check, source, self.fields, message=msg_prefix)
+            [self.run_check(check, source, self.fields, stack=asset_stack)
              for check in checks]
 
         return self.check_executions

--- a/clairmeta/dcp_check_isdcf_dcnc.py
+++ b/clairmeta/dcp_check_isdcf_dcnc.py
@@ -32,7 +32,7 @@ class Checker(CheckerBase):
         ct = cpl_node['ContentTitleText']
         self.fields, errors = parse_isdcf_string(ct)
         if errors:
-            raise CheckException('ISDCF naming convention\n' + '\n'.join(errors))
+            raise CheckException('\n'.join(errors))
 
     def check_dcnc_field_redband(self, playlist, fields):
         """ RedBand qualifier is restricted to Trailer. """

--- a/clairmeta/dcp_check_picture.py
+++ b/clairmeta/dcp_check_picture.py
@@ -17,11 +17,14 @@ class Checker(CheckerBase):
 
     def run_checks(self):
         for source in self.dcp._list_cpl:
+            asset_stack = []
 
             asset_checks = self.find_check('picture_cpl')
             [self.run_check(
-                check, source, asset, message="{} (Asset {})".format(
-                    source['FileName'], asset[1].get('Path', asset[1]['Id'])))
+                check, source, asset,
+                stack=[
+                    source['FileName'],
+                    asset[1].get('Path', asset[1]['Id'])])
              for asset in list_cpl_assets(source, filters='Picture')
              for check in asset_checks]
 

--- a/clairmeta/dcp_check_pkl.py
+++ b/clairmeta/dcp_check_pkl.py
@@ -19,14 +19,15 @@ class Checker(CheckerBase):
         self.hash_map = {}
 
         for source in self.dcp._list_pkl:
+            asset_stack = [source['FileName']]
+
             checks = self.find_check('pkl')
-            [self.run_check(check, source, message=source['FileName'])
+            [self.run_check(check, source, stack=asset_stack)
              for check in checks]
 
             asset_checks = self.find_check('assets_pkl')
-            [self.run_check(
-                check, source, asset, message="{} (Asset {})".format(
-                    source['FileName'], asset[2].get('Path', asset[2]['Id'])))
+            [self.run_check(check, source, asset,
+             stack=asset_stack + [asset[2].get('Path', asset[2]['Id'])])
              for asset in list_pkl_assets(source)
              for check in asset_checks]
 

--- a/clairmeta/dcp_check_sign.py
+++ b/clairmeta/dcp_check_sign.py
@@ -112,6 +112,8 @@ class Checker(CheckerBase):
         sources = self.dcp._list_pkl + self.dcp._list_cpl
 
         for source in sources:
+            asset_stack = [source['FileName']]
+
             if 'PackingList' in source['Info']:
                 source_xml = source['Info']['PackingList']
             else:
@@ -129,26 +131,22 @@ class Checker(CheckerBase):
                 self.cert_store.add_cert(cert_x509)
                 self.cert_list.append(cert_x509)
 
-                [self.run_check(
-                    check, cert_x509, index,
-                    message="{} (Certificate : {})".format(
-                        source['FileName'], cert_x509.get_serial_number()))
+                stack = asset_stack + ["Certificate {}".format(
+                    cert_x509.get_serial_number())]
+
+                [self.run_check(check, cert_x509, index, stack=stack)
                  for check in self.find_check('certif')]
 
-                [self.run_check(
-                    check, cert_x509, cert,
-                    message="{} (Certificate : {})".format(
-                        source['FileName'], cert_x509.get_serial_number()))
+                [self.run_check(check, cert_x509, cert, stack=stack)
                  for check in self.find_check('xml_certif')]
 
             checks = self.find_check('sign')
-            [self.run_check(check, source_xml, message=source['FileName'])
+            [self.run_check(check, source_xml, stack=asset_stack)
              for check in checks]
 
             checks = self.find_check('document')
-            [self.run_check(
-                check, source_xml,
-                source['FilePath'], message=source['FileName'])
+            [self.run_check(check, source_xml,
+                source['FilePath'], stack=asset_stack)
              for check in checks]
 
         return self.check_executions

--- a/clairmeta/dcp_check_sound.py
+++ b/clairmeta/dcp_check_sound.py
@@ -13,11 +13,12 @@ class Checker(CheckerBase):
 
     def run_checks(self):
         for source in self.dcp._list_cpl:
-
             asset_checks = self.find_check('sound_cpl')
             [self.run_check(
-                check, source, asset, message="{} ({})".format(
-                    source['FileName'], asset[1].get('Path', asset[1]['Id'])))
+                check, source, asset,
+                stack=[
+                    source['FileName'],
+                    asset[1].get('Path') or asset[1]['Id']])
              for asset in list_cpl_assets(
                 source, filters='Sound', required_keys=['Probe'])
              for check in asset_checks]

--- a/clairmeta/dcp_check_subtitle.py
+++ b/clairmeta/dcp_check_subtitle.py
@@ -161,8 +161,11 @@ class Checker(CheckerBase):
                 cpl, filters='Subtitle', required_keys=['Path'])
 
             for asset in assets:
+                stack = [cpl['FileName'], asset[1].get('Path', asset[1]['Id'])]
+
                 checks = self.find_check('subtitle_dcp')
-                [self.run_check(check, cpl, asset) for check in checks]
+                [self.run_check(check, cpl, asset, stack=stack) for check in checks]
+
                 checks = self.find_check('subtitle_cpl')
                 self.run_checks_prepare(checks, cpl, asset)
 
@@ -172,6 +175,8 @@ class Checker(CheckerBase):
         _, asset_node = asset
         path = os.path.join(self.dcp.path, asset_node['Path'])
         can_unwrap = path.endswith('.mxf') and os.path.isfile(path)
+
+        asset_stack = [cpl['FileName'], asset[1].get('Path', asset[1]['Id'])]
 
         if self.dcp.schema == 'SMPTE' and can_unwrap:
             unwrap_args = []
@@ -185,15 +190,12 @@ class Checker(CheckerBase):
                 return
 
             with unwrap_mxf(path, args=unwrap_args) as folder:
-                [self.run_check(
-                    check, cpl, asset, folder, message="{} (Asset {})".format(
-                        cpl['FileName'], asset[1].get('Path', asset[1]['Id'])))
-                    for check in checks]
+                [self.run_check(check, cpl, asset, folder, stack=asset_stack)
+                 for check in checks]
+
         elif self.dcp.schema == 'Interop':
             folder = os.path.dirname(path)
-            [self.run_check(
-                check, cpl, asset, folder, message="{} (Asset {})".format(
-                    cpl['FileName'], asset[1].get('Path', asset[1]['Id'])))
+            [self.run_check(check, cpl, asset, folder, stack=asset_stack)
              for check in checks]
 
     def check_subtitle_dcp_format(self, playlist, asset):

--- a/clairmeta/dcp_check_vol.py
+++ b/clairmeta/dcp_check_vol.py
@@ -12,7 +12,7 @@ class Checker(CheckerBase):
     def run_checks(self):
         for source in self.dcp._list_vol:
             checks = self.find_check('vol')
-            [self.run_check(check, source, message=source['FileName'])
+            [self.run_check(check, source, stack=[source['FileName']])
              for check in checks]
 
         return self.check_executions

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -74,6 +74,20 @@ class CliTest(unittest.TestCase):
             '-type', 'dcp', '-log', 'CRITICAL'])
         self.assertTrue(status)
 
+    def test_dcp_check_good_relink(self):
+        status, msg = self.launch_command([
+            'check', self.get_dcp_path(2),
+            '-type', 'dcp', '-log', 'CRITICAL',
+            '-ov', self.get_dcp_path(1)])
+        self.assertTrue(status)
+
+    def test_dcp_check_wrong_relink(self):
+        status, msg = self.launch_command([
+            'check', self.get_dcp_path(1),
+            '-type', 'dcp', '-log', 'CRITICAL',
+            '-ov', self.get_dcp_path(2)])
+        self.assertFalse(status)
+
     def test_dcp_check_bad(self):
         status, msg = self.launch_command([
             'check', self.get_dcp_path(25),


### PR DESCRIPTION
This is a first attempt to improve the built-in ClairMeta check report:
* Messages are now grouped by offending assets
* Report contains check description
* Display ContentTitleText / AnnotationText for CPL / PKL

There is still some work to make sure we export all relevant data for 3rd party report generation.