### PR TITLE
Minor fixes to probe / check

### DIFF
--- a/clairmeta/dcp_check_subtitle.py
+++ b/clairmeta/dcp_check_subtitle.py
@@ -148,6 +148,20 @@ class SubtitleUtils(object):
 
         return path, uri
 
+    def extract_subtitle_text(self, node, out_text):
+        text = []
+
+        if isinstance(node, list):
+            for elem in node:
+                text += self.extract_subtitle_text(elem, text)
+        elif isinstance(node, dict):
+            text += self.extract_subtitle_text(node.get('Font', ''), text)
+            text += self.extract_subtitle_text(node.get('Text', ''), text)
+        else:
+            text += [node]
+
+        return out_text + text
+
 
 class Checker(CheckerBase):
 
@@ -408,8 +422,12 @@ class Checker(CheckerBase):
         if not subtitles:
             return
 
+        # See SMPTE ST 428-7-2014 sections 6.3 and 6.4 for possible
+        # Subtitle Text and Font hierarchy. Note that here we just
+        # recursively iterate to extract all relevant childs whitout
+        # checking if the specific hierarchy is valid or not.
+        all_text = self.st_util.extract_subtitle_text(subtitles[0], [])
         unique_chars = set()
-        all_text = [st.get('Text', '') for st in subtitles[0]]
         for text in all_text:
             for char in text:
                 unique_chars.add(char)

--- a/clairmeta/dcp_parse.py
+++ b/clairmeta/dcp_parse.py
@@ -159,7 +159,16 @@ def cpl_reels_parse(cpl_node):
         for key, val in six.iteritems(asset_mapping):
             if key in assetlist:
                 out_reel['Assets'][val] = assetlist[key]
+
                 asset = out_reel['Assets'][val]
+                # Duplicated assets is a fatal error
+                if isinstance(asset, list):
+                    raise Exception(
+                        "Duplicated {} asset in CPL {}, Reel {}".format(
+                            key,
+                            cpl_node.get('ContentTitleText', ''),
+                            pos))
+
                 discover_schema(asset)
 
                 # Encryption


### PR DESCRIPTION
This pull request address issues reported in #155, specifically 2 DCPs reported by @jamiegau were tested.

EDCF-SMPTE-Bv2_TST_S_EN-EN_OV_51-HI-VI-Atmos_2K_20161020_DTU_SMPTE_OV
*  Subtitle's Text and Font elements hierarchy were making the font check crash, this should be fixed
*  Note that this DCP is still considered not valid by ClairMeta
    *  IntrinsicDuration does not match between CPL and MXF for the subtitles assets
    *  Leaf Certificate for digital signature missing the ContentSigner role
    *  Atmos essence coding UL inside the CPL contains an extra dot ( 060e2b34.0401.0105.0e090604.00000000 instead of 060e2b34.04010105.0e090604.00000000)

FMSC-Ad-June_ADV_F_2K_20180604_SMPTE_OV
*  This package will remain considered as broken by ClairMeta because the CPL only Reel contains two MainSound asset. However, the error message was improved to describe the error.