### PR TITLE
Improve console progress report user extensibility

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -187,7 +187,7 @@ Contributing
    pipenv shell
    # Code...
    # Get tests resources
-   git clone https://github.com/Ymagis/ClairMeta_Data tests/resources 
+   git clone https://github.com/Ymagis/ClairMeta_Data tests/resources
    # Run tests
    nosetests --nocapture --with-doctest --doctest-options=+ELLIPSIS --with-coverage --cover-package=clairmeta
    # Leave virtual environment

--- a/README.rst
+++ b/README.rst
@@ -107,9 +107,12 @@ As a python library :
     # Check DCP VF against OV
     status, report = dcp.check(ov_path="/path/to/dcp_ov")
 
-    # Check DCP with console progression report
+    # Check DCP with default console progression report
     from clairmeta.utils.file import ConsoleProgress
-    status, report = dcp.check(hash_callback=ConsoleProgress)
+    status, report = dcp.check(hash_callback=ConsoleProgress())
+    # Alternatives
+    # - function matching utils.file.ConsoleProgress.__call__ signature
+    # - derived class from utils.file.ConsoleProgress
 
 Profiles
 ~~~~~~~~

--- a/clairmeta/cli.py
+++ b/clairmeta/cli.py
@@ -46,7 +46,7 @@ def cli_check(args):
             if args.log:
                 check_profile['log_level'] = args.log
             if args.progress:
-                callback = ConsoleProgress
+                callback = ConsoleProgress()
 
             status, _ = DCP(args.path, kdm=args.kdm, pkey=args.key).check(
                 profile=check_profile, ov_path=args.ov, hash_callback=callback)

--- a/clairmeta/dcp_check.py
+++ b/clairmeta/dcp_check.py
@@ -10,6 +10,7 @@ from clairmeta.settings import DCP_CHECK_SETTINGS
 from clairmeta.profile import get_default_profile
 from clairmeta.dcp_utils import list_cpl_assets, cpl_probe_asset
 from clairmeta.dcp_check_base import CheckerBase, CheckException
+from clairmeta.utils.file import ConsoleProgress
 from clairmeta.utils.sys import all_keys_in_dict
 
 
@@ -31,9 +32,16 @@ class DCPChecker(CheckerBase):
         super(DCPChecker, self).__init__(dcp, profile)
         self.ov_path = ov_path
         self.ov_dcp = None
+
         self.hash_callback = hash_callback
-        if self.hash_callback and inspect.isclass(self.hash_callback):
-            self.hash_callback = hash_callback(self.dcp.size)
+        if not self.hash_callback:
+            pass
+        elif isinstance(self.hash_callback, ConsoleProgress):
+            self.hash_callback._total_size = self.dcp.size
+        elif inspect.isclass(self.hash_callback):
+            raise CheckException(
+                "Invalid callback, please provide a function"
+                " or instance of ConsoleProgress (or derivate).")
 
         self.check_modules = {}
         self.load_modules()

--- a/clairmeta/dcp_check_subtitle.py
+++ b/clairmeta/dcp_check_subtitle.py
@@ -148,21 +148,21 @@ class SubtitleUtils(object):
 
         return path, uri
 
-    def extract_subtitle_text(self, node, out_text):
+    def extract_subtitle_text(self, node):
         text = []
 
         if isinstance(node, list):
             for elem in node:
-                text += self.extract_subtitle_text(elem, [])
+                text += self.extract_subtitle_text(elem)
         elif isinstance(node, dict):
             if 'Font' in node:
-                text += self.extract_subtitle_text(node['Font'], [])
+                text = self.extract_subtitle_text(node['Font'])
             if 'Text' in node:
-                text += self.extract_subtitle_text(node['Text'], [])
+                text = self.extract_subtitle_text(node['Text'])
         else:
-            text += [node]
+            text = [node]
 
-        return out_text + text
+        return text
 
 
 class Checker(CheckerBase):
@@ -430,7 +430,7 @@ class Checker(CheckerBase):
         # Subtitle Text and Font hierarchy. Note that here we just
         # recursively iterate to extract all relevant childs whitout
         # checking if the specific hierarchy is valid or not.
-        all_text = self.st_util.extract_subtitle_text(subtitles[0], [])
+        all_text = self.st_util.extract_subtitle_text(subtitles[0])
         unique_chars = set()
         for text in all_text:
             for char in text:

--- a/clairmeta/dcp_check_subtitle.py
+++ b/clairmeta/dcp_check_subtitle.py
@@ -153,10 +153,12 @@ class SubtitleUtils(object):
 
         if isinstance(node, list):
             for elem in node:
-                text += self.extract_subtitle_text(elem, text)
+                text += self.extract_subtitle_text(elem, [])
         elif isinstance(node, dict):
-            text += self.extract_subtitle_text(node.get('Font', ''), text)
-            text += self.extract_subtitle_text(node.get('Text', ''), text)
+            if 'Font' in node:
+                text += self.extract_subtitle_text(node['Font'], [])
+            if 'Text' in node:
+                text += self.extract_subtitle_text(node['Text'], [])
         else:
             text += [node]
 

--- a/clairmeta/utils/file.py
+++ b/clairmeta/utils/file.py
@@ -89,15 +89,11 @@ def temporary_dir():
 
 class ConsoleProgress(object):
 
-    def __init__(self, total_size):
-        """ ConsoleProgress constructor.
+    def __init__(self):
+        """ ConsoleProgress constructor. """
+        self._total_size = None
 
-            Args:
-                total_size (int): Total size in Bytes to process
-
-        """
         self.total_processed = 0
-        self.total_size = total_size
         self.total_elapsed = 0
 
     def __call__(self, file_path, file_processed, file_size, file_elapsed):
@@ -121,11 +117,11 @@ class ConsoleProgress(object):
             file_progress_size = int(file_progress * col_width)
             file_bar_size = col_width - file_progress_size
 
-            total_progress = min(1, (processed / self.total_size))
+            total_progress = min(1, (processed / self._total_size))
             total_progress_size = int(total_progress * col_width)
             total_bar_size = col_width - total_progress_size
 
-            eta_sec = (self.total_size - processed) / (processed / elapsed)
+            eta_sec = (self._total_size - processed) / (processed / elapsed)
             eta_str = time.strftime("%H:%M:%S", time.gmtime(eta_sec))
 
             sys.stdout.write("ETA {} [{}] {:.2f}% - File [{}] {:.2f}% - {}\r".format(


### PR DESCRIPTION
Example usage, using 3 different ways:

```
from clairmeta import DCP
from clairmeta.utils.file import ConsoleProgress


class MyProgress(ConsoleProgress):

    def __init__(self, my_setting_1, my_setting_2):
        super(MyProgress, self).__init__()
        self.my_setting_1 = my_setting_1
        self.my_setting_2 = my_setting_2

    def __call__(self, file_path, file_processed, file_size, file_elapsed):
        super(MyProgress, self).__call__(file_path, file_processed, file_size, file_elapsed)
        print(self.my_setting_1, self.my_setting_2)

def function_callback(file_path, file_processed, file_size, file_elapsed):
    print(file_path, file_processed, file_size, file_elapsed)


dcp = DCP("tests/resources/DCP/ECL-SET/ECL01-SINGLE-CPL_TST_S_EN-XX_UK-U_71_2K_DI_20171218_ECL_IOP_OV")
status, report = dcp.check(hash_callback=function_callback)

dcp = DCP("tests/resources/DCP/ECL-SET/ECL01-SINGLE-CPL_TST_S_EN-XX_UK-U_71_2K_DI_20171218_ECL_IOP_OV")
status, report = dcp.check(hash_callback=ConsoleProgress())

dcp = DCP("tests/resources/DCP/ECL-SET/ECL01-SINGLE-CPL_TST_S_EN-XX_UK-U_71_2K_DI_20171218_ECL_IOP_OV")
progress = MyProgress(1, 2)
status, report = dcp.check(hash_callback=progress)
```