### PR TITLE
Support for DCP check report dict-json-xml formats

### DIFF
--- a/clairmeta/dcp_check_base.py
+++ b/clairmeta/dcp_check_base.py
@@ -41,6 +41,21 @@ class CheckExecution(object):
         docstring_lines = self.doc.split('\n')
         return docstring_lines[0].strip() if docstring_lines else c.name
 
+    def to_dict(self):
+        """ Returns a dictionary representation. """
+        return {
+            'name': self.name,
+            'pretty_name': self.short_desc(),
+            'doc': self.doc,
+            'message': self.message,
+            'valid': self.valid,
+            'bypass': self.bypass,
+            'seconds_elapsed': self.seconds_elapsed,
+            'asset_stack': self.asset_stack,
+            'criticality': self.criticality
+        }
+
+
 
 class CheckerBase(object):
     """ Base class for check module, provide check discover and run utilities.

--- a/clairmeta/dcp_check_report.py
+++ b/clairmeta/dcp_check_report.py
@@ -148,3 +148,17 @@ class CheckReport(object):
                 return desc
 
         return ''
+
+    def to_dict(self):
+        """ Returns a dictionary representation. """
+        return {
+            'dcp_path': self.dcp.path,
+            'dcp_size': self.dcp.size,
+            'valid': self.valid(),
+            'profile': self.profile,
+            'date': self.date,
+            'duration_seconds': self.duration,
+            'message': self.pretty_str(),
+            'unique_checks_count': self.checks_count(),
+            'checks': [c.to_dict() for c in self.checks],
+        }

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,7 @@
 # Clairmeta - (C) YMAGIS S.A.
 # See LICENSE for more information
 
+import collections
 import unittest
 import os
 import json
@@ -48,6 +49,12 @@ class CliTest(unittest.TestCase):
         args = parser.parse_args(args)
         return args.func(args)
 
+    def test_dcp_probe_formating_dict(self):
+        status, msg = self.launch_command([
+            'probe', self.get_dcp_path(1),
+            '-type', 'dcp', '-format', 'dict'])
+        self.assertTrue(isinstance(eval(msg), collections.Mapping))
+
     def test_dcp_probe_formating_xml(self):
         status, msg = self.launch_command([
             'probe', self.get_dcp_path(1),
@@ -67,6 +74,24 @@ class CliTest(unittest.TestCase):
         self.assertEqual(
             json.dumps(json_test, indent=4, sort_keys=True),
             json.dumps(json_gold, indent=4, sort_keys=True))
+
+    def test_dcp_check_formating_dict(self):
+        status, msg = self.launch_command([
+            'check', self.get_dcp_path(1),
+            '-type', 'dcp', '-format', 'dict'])
+        self.assertTrue(isinstance(eval(msg), collections.Mapping))
+
+    def test_dcp_check_formating_xml(self):
+        status, msg = self.launch_command([
+            'check', self.get_dcp_path(1),
+            '-type', 'dcp', '-format', 'xml'])
+        ET.XML(msg)
+
+    def test_dcp_check_formating_json(self):
+        status, msg = self.launch_command([
+            'check', self.get_dcp_path(1),
+            '-type', 'dcp', '-format', 'json'])
+        json.loads(msg, object_pairs_hook=OrderedDict)
 
     def test_dcp_check_good(self):
         status, msg = self.launch_command([


### PR DESCRIPTION
This is a quick stab at implementing a format settings for the DCP check report, trying to get similar functionality we currently have for the probe report.