### PR TITLE
Refactor check error handling

### DIFF
--- a/clairmeta/dcp_check_atmos.py
+++ b/clairmeta/dcp_check_atmos.py
@@ -1,7 +1,7 @@
 # Clairmeta - (C) YMAGIS S.A.
 # See LICENSE for more information
 
-from clairmeta.dcp_check import CheckerBase, CheckException
+from clairmeta.dcp_check import CheckerBase
 from clairmeta.dcp_utils import list_cpl_assets
 from clairmeta.settings import DCP_SETTINGS
 
@@ -37,19 +37,25 @@ class Checker(CheckerBase):
         mxf_ul = asset['Probe'].get('DataEssenceCoding', '')
 
         if not cpl_ul:
-            raise CheckException("Missing Atmos DataType tag (CPL/AuxData")
+            self.fatal_error(
+                "Missing Atmos DataType tag (CPL/AuxData)",
+                "missing_cpl")
         elif not mxf_ul:
-            raise CheckException("Missing Atmos Essence Coding UL (MXF)")
+            self.fatal_error(
+                "Missing Atmos Essence Coding UL (MXF)",
+                "missing_mxf")
 
         cpl_ul, mxf_ul = cpl_ul.lower(), mxf_ul.lower()
         if cpl_ul != mxf_ul:
-            raise CheckException(
+            self.error(
                 "Incoherent Atmos Data Essence Coding, CPL {} / MXF {}"
-                .format(cpl_ul, mxf_ul))
+                .format(cpl_ul, mxf_ul),
+                "incoherent")
         elif mxf_ul != ul:
-            raise CheckException(
+            self.error(
                 "Unknown Atmos Data Essence Coding, expecting {} but got {}"
-                .format(ul, mxf_ul))
+                .format(ul, mxf_ul),
+                "unknown")
 
     def check_atmos_cpl_channels(self, playlist, asset):
         """ Atmos maximum channels count.
@@ -66,11 +72,14 @@ class Checker(CheckerBase):
         max_cc = asset['Probe'].get('MaxChannelCount')
 
         if not max_cc:
-            raise CheckException("Missing MaxChannelCount field")
+            self.error(
+                "Missing MaxChannelCount field",
+                "missing")
         elif max_cc > max_atmos:
-            raise CheckException(
+            self.error(
                 "Invalid Atmos MaxChannelCount, got {} but maximum is {}"
-                .format(max_cc, max_atmos))
+                .format(max_cc, max_atmos),
+                "invalid")
 
     def check_atmos_cpl_objects(self, playlist, asset):
         """ Atmos maximum objects count.
@@ -87,8 +96,11 @@ class Checker(CheckerBase):
         max_obj = asset['Probe'].get('MaxObjectCount')
 
         if not max_obj:
-            raise CheckException("Missing MaxObjectCount field")
+            self.error(
+                "Missing MaxObjectCount field",
+                "missing")
         elif max_obj > max_atmos:
-            raise CheckException(
+            self.error(
                 "Invalid Atmos MaxObjectCount, got {} but maximum is {}"
-                .format(max_obj, max_atmos))
+                .format(max_obj, max_atmos),
+                "invalid")

--- a/clairmeta/dcp_check_execution.py
+++ b/clairmeta/dcp_check_execution.py
@@ -57,14 +57,9 @@ class CheckError(object):
             return self.parent_name
 
     def short_desc(self):
-        """ Returns first line of the docstring or function name. """
-        lines = self.parent_doc.split('\n')
-        outer = lines[0].strip() if lines else self.parent_name
-
+        """ Returns first line of the documentation. """
         lines = list(filter(None, self.doc.split('\n')))
-        inner = " (" + lines[0].strip() + ")" if lines else ""
-
-        return "{}{}".format(outer, inner)
+        return lines[0].strip() if lines else ""
 
     def to_dict(self):
         """ Returns a dictionary representation. """

--- a/clairmeta/dcp_check_execution.py
+++ b/clairmeta/dcp_check_execution.py
@@ -1,0 +1,148 @@
+# Clairmeta - (C) YMAGIS S.A.
+# See LICENSE for more information
+
+import six
+
+
+
+class CheckException(Exception):
+    """ Non recoverable errors while checking a DCP.
+
+        This is not to be used for regular check errors, where we instead use
+        ``error()`` and ``fatal_error()`` methods.
+
+    """
+    pass
+
+
+ERROR_SILENT = 0
+ERROR_INFO = 1
+ERROR_WARNING = 2
+ERROR_ERROR = 3
+
+ERROR_FROM_STR = {
+    "SILENT": ERROR_SILENT,
+    "INFO": ERROR_INFO,
+    "WARNING": ERROR_WARNING,
+    "ERROR": ERROR_ERROR
+}
+
+STR_FROM_ERROR = {
+    v: k for k, v in six.iteritems(ERROR_FROM_STR)
+}
+
+def ErrorLevelFromString(error_str):
+    return ERROR_FROM_STR[error_str]
+
+
+def ErrorLevelToString(error_level):
+    return STR_FROM_ERROR[error_level]
+
+
+class CheckError(object):
+    """ Error reporting from whithin checks accumulate a list of errors. """
+
+    def __init__(self, msg, name="", doc=""):
+        self.name = name
+        self.parent_name = ""
+        self.doc = doc
+        self.parent_doc = doc
+        self.message = msg
+        self.criticality = "ERROR"
+
+    def full_name(self):
+        if self.name:
+            return "{}_{}".format(self.parent_name, self.name)
+        else:
+            return self.parent_name
+
+    def short_desc(self):
+        """ Returns first line of the docstring or function name. """
+        lines = self.parent_doc.split('\n')
+        outer = lines[0].strip() if lines else self.parent_name
+
+        lines = list(filter(None, self.doc.split('\n')))
+        inner = " (" + lines[0].strip() + ")" if lines else ""
+
+        return "{}{}".format(outer, inner)
+
+    def to_dict(self):
+        """ Returns a dictionary representation. """
+        return {
+            'name': self.name,
+            'pretty_name': self.short_desc(),
+            'doc': self.doc,
+            'message': self.message,
+            'criticality': self.criticality,
+        }
+
+class CheckExecution(object):
+    """ Check execution with status and related metadatas. """
+
+    def __init__(self, func):
+        """ Constructor for CheckExecution.
+
+            Args:
+                func (function): Check function.
+
+        """
+        self.name = func.__name__
+        self.doc = func.__doc__
+        self.bypass = False
+        self.seconds_elapsed = 0
+        self.asset_stack = []
+        self.errors = []
+
+    def short_desc(self):
+        """ Returns first line of the docstring or function name. """
+        docstring_lines = self.doc.split('\n')
+        return docstring_lines[0].strip() if docstring_lines else c.name
+
+    def is_valid(self, criticality="ERROR"):
+        """ Returns whether check raised any errors is above ``criticality``.
+
+            Args:
+                criticality (str, optional): Maximum error level to be
+                    considered invalid.
+
+            Returns:
+                Boolean
+
+        """
+        error_level = ErrorLevelFromString(criticality)
+        return not any([
+            ErrorLevelFromString(e.criticality) >= error_level
+            for e in self.errors]
+        )
+
+    def has_errors(self, criticality=""):
+        """ Returns whether check raised any errors of ``criticality``.
+
+            Args:
+                criticality (str, optional): Error level to consider, if empty
+                    will look for all errors.
+
+            Returns:
+                Boolean
+
+        """
+        if not criticality:
+            return self.errors != []
+        else:
+            error_level = ErrorLevelFromString(criticality)
+            return any([
+                e for e in self.errors
+                if e.criticality == error_level]
+            )
+
+    def to_dict(self):
+        """ Returns a dictionary representation. """
+        return {
+            'name': self.name,
+            'pretty_name': self.short_desc(),
+            'doc': self.doc,
+            'bypass': self.bypass,
+            'seconds_elapsed': self.seconds_elapsed,
+            'asset_stack': self.asset_stack,
+            'errors': [e.to_dict() for e in self.errors]
+        }

--- a/clairmeta/dcp_check_picture.py
+++ b/clairmeta/dcp_check_picture.py
@@ -4,7 +4,7 @@
 import six
 
 from clairmeta.utils.time import compare_ratio
-from clairmeta.dcp_check import CheckerBase, CheckException
+from clairmeta.dcp_check import CheckerBase
 from clairmeta.dcp_utils import list_cpl_assets
 from clairmeta.settings import DCP_SETTINGS
 
@@ -74,7 +74,7 @@ class Checker(CheckerBase):
                 [resolution in res for res in dci_resolutions])
 
             if not is_dci_res:
-                raise CheckException("Picture have non-DCI Resolution")
+                self.error("Picture have non-DCI Resolution")
 
     def check_picture_cpl_encoding(self, playlist, asset):
         """ Picture wavelet transform levels SMPTE compliance.
@@ -101,7 +101,7 @@ class Checker(CheckerBase):
 
             is_dci = resolution_name in levels_map
             if is_dci and levels_map[resolution_name] != levels:
-                raise CheckException(
+                self.error(
                     "Picture must have {} wavelet transform levels, {}"
                     " found".format(levels_map[resolution_name], levels))
 
@@ -121,7 +121,7 @@ class Checker(CheckerBase):
             t_bitrate = dci_bitrate + tolerance
 
             if max_bitrate > t_bitrate:
-                raise CheckException(
+                self.error(
                     "Exceed DCI maximum bitrate ({} Mb/s) : {} Mb/s".format(
                         t_bitrate, max_bitrate))
 
@@ -139,7 +139,7 @@ class Checker(CheckerBase):
             t_bitrate = dci_bitrate - (dci_bitrate * margin) / 100.0
 
             if avg_bitrate > t_bitrate:
-                raise CheckException(
+                self.error(
                     "Exceed DCI safe average bitrate ({} Mb/s) "
                     ": {} Mb/s".format(t_bitrate, avg_bitrate))
 
@@ -160,13 +160,11 @@ class Checker(CheckerBase):
 
             if resolution in self.settings['resolutions']['2K']:
                 if editrate not in editrate_map['2K'][dimension]:
-                    raise CheckException(
-                        'Invalid EditRate {} for 2K {} content'
+                    self.error('Invalid EditRate {} for 2K {} content'
                         .format(editrate, dimension))
             elif resolution in self.settings['resolutions']['4K']:
                 if editrate not in editrate_map['4K'][dimension]:
-                    raise CheckException(
-                        'Invalid EditRate {} for 4K {} content'
+                    self.error('Invalid EditRate {} for 4K {} content'
                         .format(editrate, dimension))
 
     def check_picture_cpl_archival_framerate(self, playlist, asset):
@@ -183,7 +181,7 @@ class Checker(CheckerBase):
 
         for archival_editrate in archival_editrates:
             if compare_ratio(editrate, archival_editrate):
-                raise CheckException(
+                self.error(
                     "Archival EditRate {} may not play safely on all hardware"
                     .format(editrate))
 
@@ -200,7 +198,7 @@ class Checker(CheckerBase):
         series2_map = self.settings['editrates_min_series2']
 
         if editrate >= series2_map[dimension]:
-            raise CheckException(
+            self.error(
                 "EditRate {} require an HFR capable projection server "
                 "(Series II), may not play safely on all hardware".format(
                     editrate))
@@ -218,7 +216,7 @@ class Checker(CheckerBase):
         is_stereo = asset['Stereoscopic']
 
         if is_stereo and editrate * 2 != framerate:
-            raise CheckException("3D FrameRate must be double of EditRate")
+            self.error("3D FrameRate must be double of EditRate")
 
         if not is_stereo and editrate != framerate:
-            raise CheckException("2D FrameRate must be equal to EditRate")
+            self.error("2D FrameRate must be equal to EditRate")

--- a/clairmeta/dcp_check_pkl.py
+++ b/clairmeta/dcp_check_pkl.py
@@ -4,7 +4,7 @@
 import os
 
 from clairmeta.utils.file import shaone_b64
-from clairmeta.dcp_check import CheckerBase, CheckException
+from clairmeta.dcp_check import CheckerBase
 from clairmeta.dcp_check_utils import check_xml, check_issuedate
 from clairmeta.dcp_utils import list_pkl_assets
 
@@ -37,6 +37,7 @@ class Checker(CheckerBase):
         """ PKL XML syntax and structure check. """
         pkl_node = pkl['Info']['PackingList']
         check_xml(
+            self,
             pkl['FilePath'],
             pkl_node['__xmlns__'],
             pkl_node['Schema'],
@@ -56,15 +57,14 @@ class Checker(CheckerBase):
                 empty_fields.append(f)
 
         if empty_fields:
-            raise CheckException("Empty {} field(s)".format(
-                ", ".join(empty_fields)))
+            self.error("Empty {} field(s)".format( ", ".join(empty_fields)))
 
     def check_pkl_issuedate(self, pkl):
         """ PKL Issue Date validation.
 
             References: N/A
         """
-        check_issuedate(pkl['Info']['PackingList']['IssueDate'])
+        check_issuedate(self, pkl['Info']['PackingList']['IssueDate'])
 
     def check_assets_pkl_referenced_by_assetamp(self, pkl, asset):
         """ PKL assets shall be present in AssetMap.
@@ -74,7 +74,7 @@ class Checker(CheckerBase):
         uuid, _, _ = asset
         # Note : dcp._list_asset is directly extracted from Assetmap
         if uuid not in self.dcp._list_asset.keys():
-            raise CheckException("Not present in Assetmap")
+            self.error("Not present in Assetmap")
 
     def check_assets_pkl_size(self, pkl, asset):
         """ PKL assets size check.
@@ -90,9 +90,8 @@ class Checker(CheckerBase):
         actual_size = os.path.getsize(path)
 
         if actual_size != asset_size:
-            raise CheckException(
-                "Invalid size, expected {} but got {}".format(
-                    asset_size, actual_size))
+            self.error("Invalid size, expected {} but got {}".format(
+                asset_size, actual_size))
 
     def check_assets_pkl_hash(self, pkl, asset):
         """ PKL assets hash check.
@@ -111,6 +110,5 @@ class Checker(CheckerBase):
             self.hash_map[asset_id] = shaone_b64(path, self.hash_callback)
 
         if self.hash_map[asset_id] != asset_hash:
-            raise CheckException(
-                "Corrupt file, expected hash {} but got {}".format(
-                    asset_hash, self.hash_map[asset_id]))
+            self.error("Corrupt file, expected hash {} but got {}".format(
+                asset_hash, self.hash_map[asset_id]))

--- a/clairmeta/dcp_check_report.py
+++ b/clairmeta/dcp_check_report.py
@@ -77,14 +77,20 @@ class CheckReport(object):
         status_map = nested_dict()
 
         # Accumulate all failed check and stack them by asset
-        for c in self.checks_failed():
-            for e in c.errors:
-                asset = status_map[str(e.criticality)]
-                for filename in c.asset_stack:
+        for check in self.checks_failed():
+            lines = [". {}".format(check.short_desc())]
+
+            for error in check.errors:
+                asset = status_map[str(error.criticality)]
+
+                for filename in check.asset_stack:
                     asset = asset[filename]
 
-                message = ". {}\n{}".format(e.short_desc(), e.message)
-                asset['msg'] = asset.get('msg', []) + [message]
+                desc = error.short_desc()
+                desc = ". {}\n".format(desc) if desc else ""
+                lines.append("{}{}".format(desc, error.message))
+
+            asset['msg'] = asset.get('msg', []) + ["\n".join(lines)]
 
         for status, vals in six.iteritems(status_map):
             out_stack = []

--- a/clairmeta/dcp_check_sound.py
+++ b/clairmeta/dcp_check_sound.py
@@ -1,7 +1,7 @@
 # Clairmeta - (C) YMAGIS S.A.
 # See LICENSE for more information
 
-from clairmeta.dcp_check import CheckerBase, CheckException
+from clairmeta.dcp_check import CheckerBase
 from clairmeta.dcp_utils import list_cpl_assets
 from clairmeta.settings import DCP_SETTINGS
 
@@ -36,7 +36,7 @@ class Checker(CheckerBase):
         cc = asset['Probe']['ChannelCount']
 
         if cc > channels:
-            raise CheckException(
+            self.error(
                 "Invalid Sound ChannelCount, should be less than {} but got {}"
                 "".format(channels, cc))
 
@@ -56,7 +56,7 @@ class Checker(CheckerBase):
         cc = asset['Probe']['ChannelCount']
 
         if cc % 2 != 0:
-            raise CheckException(
+            self.error(
                 "Invalid Sound ChannelCount, should be an even number, got {}"
                 "".format(cc))
 
@@ -74,7 +74,7 @@ class Checker(CheckerBase):
         if cf in configurations:
             label, min_cc, max_cc = configurations[cf]
             if label and cc < min_cc or cc > max_cc:
-                raise CheckException(
+                self.error(
                     "Invalid Sound ChannelCount, {} require between {} and {} "
                     "channels, got {}".format(label, min_cc, max_cc, cc))
 
@@ -89,7 +89,7 @@ class Checker(CheckerBase):
         sr = asset['Probe']['AudioSamplingRate']
 
         if sr not in rates:
-            raise CheckException(
+            self.error(
                 "Invalid Sound SamplingRate, expected {} but got {}".format(
                     rates, sr))
 
@@ -104,7 +104,7 @@ class Checker(CheckerBase):
         depth = asset['Probe']['QuantizationBits']
 
         if depth != bitdepth:
-            raise CheckException(
+            self.error(
                 "Invalid Sound Quantization, expected {} but got {}".format(
                     bitdepth, depth))
 
@@ -119,6 +119,6 @@ class Checker(CheckerBase):
         cc = asset['Probe']['ChannelCount']
 
         if al != cc * align:
-            raise CheckException(
+            self.error(
                 "Invalid Sound BlockAlign, expected {} but got {} (it should "
                 "be ChannelCount x 3)".format(cc * align, al))

--- a/clairmeta/dcp_check_utils.py
+++ b/clairmeta/dcp_check_utils.py
@@ -8,7 +8,6 @@ from dateutil import parser
 from clairmeta.logger import get_log
 from clairmeta.utils.uuid import check_uuid
 from clairmeta.utils.xml import validate_xml
-from clairmeta.dcp_check import CheckException
 from clairmeta.settings import DCP_SETTINGS
 
 
@@ -18,17 +17,17 @@ def get_schema(name):
             return v
 
 
-def check_xml(xml_path, xml_ns, schema_type, schema_dcp):
+def check_xml(checker, xml_path, xml_ns, schema_type, schema_dcp):
     # Correct namespace
     schema_id = get_schema(xml_ns)
     if not schema_id:
-        raise CheckException("Namespace unknown : {}".format(xml_ns))
+        checker.error("Namespace unknown : {}".format(xml_ns), "namespace")
 
     # Coherence with package schema
     if schema_type != schema_dcp:
-        raise CheckException(
-            "Schema is not valid got {} but was expecting {}".format(
-                schema_type, schema_dcp))
+        message = "Schema is not valid got {} but was expecting {}".format(
+            schema_type, schema_dcp)
+        checker.error(message, "schema_coherence")
 
     # XSD schema validation
     try:
@@ -36,29 +35,28 @@ def check_xml(xml_path, xml_ns, schema_type, schema_dcp):
     except LookupError as e:
         get_log().info("Schema validation skipped : {}".format(xml_path))
     except Exception as e:
-        raise CheckException(
+        message = (
             "Schema validation error : {}\n"
             "Using schema : {}".format(str(e), schema_id))
+        checker.error(message, "schema_validation")
 
 
-def check_issuedate(date):
+def check_issuedate(checker, date):
     # As a reminder, date should be already correctly formatted as checked
     # by XSD validation.
     parse_date = parser.parse(date)
     now_date = datetime.now().replace(tzinfo=parse_date.tzinfo)
 
     if parse_date > now_date:
-        raise CheckException("IssueDate is post dated : {}".format(
-            parse_date))
+        self.error("IssueDate is post dated : {}".format(parse_date))
 
 
-def compare_uuid(uuid_to_check, uuid_reference):
+def compare_uuid(checker, uuid_to_check, uuid_reference):
     name, uuid = uuid_to_check
     name_ref, uuid_ref = uuid_reference
 
     if not check_uuid(uuid):
-        raise CheckException("Invalid {} uuid found : {}".format(
-            name, uuid))
+        checker.error("Invalid {} uuid found : {}".format(name, uuid))
     if uuid.lower() != uuid_ref.lower():
-        raise CheckException("Uuid {} ({}) not equal to {} ({})".format(
+        checker.error("Uuid {} ({}) not equal to {} ({})".format(
             name, uuid, name_ref, uuid_ref))

--- a/clairmeta/dcp_check_vol.py
+++ b/clairmeta/dcp_check_vol.py
@@ -1,7 +1,7 @@
 # Clairmeta - (C) YMAGIS S.A.
 # See LICENSE for more information
 
-from clairmeta.dcp_check import CheckerBase, CheckException
+from clairmeta.dcp_check import CheckerBase
 from clairmeta.dcp_check_utils import check_xml
 
 
@@ -29,6 +29,7 @@ class Checker(CheckerBase):
             return
 
         check_xml(
+            self,
             vol['FilePath'],
             vol['Info']['VolumeIndex']['__xmlns__'],
             vol['Info']['VolumeIndex']['Schema'],
@@ -46,6 +47,6 @@ class Checker(CheckerBase):
         }
 
         if mandatory_name[schema] != vol['FileName']:
-            raise CheckException(
+            self.error(
                 "{} VolIndex must be named {}, got {} instead".format(
                     schema, mandatory_name[schema], vol['FileName']))

--- a/clairmeta/profile.py
+++ b/clairmeta/profile.py
@@ -11,15 +11,14 @@ DCP_CHECK_PROFILE = {
     # Checker criticality
     # Base level is default and can be overrided per check using its name
     # Incomplete name allowed, the best match will be selected automatically
+    # Wildcard character allowed for regex based matching
     # 4 levels : ERROR, WARNING, INFO and SILENT.
     'criticality': {
         'default': 'ERROR',
         'check_dcnc_': 'WARNING',
         'check_dcp_foreign_files': 'WARNING',
         'check_assets_am_volindex_one': 'WARNING',
-        'check_am_empty_text_fields': 'INFO',
-        'check_pkl_empty_text_fields': 'WARNING',
-        'check_cpl_empty_text_fields': 'WARNING',
+        'check_*_empty_text_fields': 'WARNING',
         'check_cpl_contenttitle_annotationtext_match': 'WARNING',
         'check_cpl_contenttitle_pklannotationtext_match': 'WARNING',
         'check_assets_cpl_missing_from_vf': 'WARNING',

--- a/tests/test_dcp_check.py
+++ b/tests/test_dcp_check.py
@@ -191,9 +191,6 @@ class DCPCheckReportTest(CheckerTestBase):
         error = check.errors[0]
         self.assertEqual(error.full_name(), "check_picture_cpl_max_bitrate")
         self.assertEqual(
-            error.short_desc(),
-            "Picture maximum bitrate DCI compliance.")
-        self.assertEqual(
             error.message,
             "Exceed DCI maximum bitrate (250.05 Mb/s) : 358.25 Mb/s")
         self.assertTrue(error.criticality == "ERROR")


### PR DESCRIPTION
This PR implement a new way of handling errors within checks, hopefully enabling simpler implementation and flexibility.
*  Error are simply appended to an internal error list (get reset'ed between each check execution)
*  Error can specify a custom name and documentation, this allow per-error control of report error level. Existing tests that returns multiple errors may or may not tag the errors, this should probably not be mandatory and can be added on a per case basis if we need the extra flexibility. The current PR added such tag for some checks but that's somewhat arbitrary.
*  Fatal error can be used to mimic the previous behaviour

Remaining tasks:
- [x] Check report json / xml output need to be checked and difference from previous version listed. Human friendly report may also be improved when multiple errors are accumulated within a single check, eg. to avoid duplication of the description.