### PR TITLE
Prototyping a file exception list for DCP check. File list in settings.py

### DIFF
--- a/clairmeta/dcp.py
+++ b/clairmeta/dcp.py
@@ -311,7 +311,8 @@ class DCP(object):
             self,
             ov_path=ov_path,
             hash_callback=hash_callback,
-            bypass_list=profile.get("bypass")
+            bypass_list=profile.get("bypass"),
+            allowed_foreign_files=profile.get("allowed_foreign_files")
         )
         self.checks = self.checker.check()
 

--- a/clairmeta/dcp_check.py
+++ b/clairmeta/dcp_check.py
@@ -26,7 +26,7 @@ class CheckerBase(object):
 
     ERROR_NAME_RE = re.compile(r"^\w+$")
 
-    def __init__(self, dcp, ov_path=None, hash_callback=None, bypass_list=None):
+    def __init__(self, dcp, ov_path=None, hash_callback=None, bypass_list=None, allowed_foreign_files=None):
         """ CheckerBase constructor.
 
             Args:
@@ -43,6 +43,7 @@ class CheckerBase(object):
         self.errors = []
         self.report = None
         self.bypass_list = bypass_list if bypass_list else []
+        self.allowed_foreign_files = allowed_foreign_files if allowed_foreign_files else []
         self.check_modules = {}
         self.ov_path = ov_path
         self.ov_dcp = None
@@ -66,6 +67,7 @@ class CheckerBase(object):
                 module = importlib.import_module(module_path)
                 checker = module.Checker(self.dcp)
                 checker.ov_path = self.ov_path
+                checker.allowed_foreign_files = self.allowed_foreign_files
                 checker.hash_callback = self.hash_callback
                 self.check_modules[v] = checker
             except (ImportError, Exception) as e:

--- a/clairmeta/dcp_check_global.py
+++ b/clairmeta/dcp_check_global.py
@@ -60,11 +60,9 @@ class Checker(CheckerBase):
         list_asset_path += self.dcp._list_vol_path
         list_asset_path += self.dcp._list_am_path
 
-        allowed_foreign_files = DCP_CHECK_PROFILE['allowed_foreign_files']
-
         allowed_foreign_files_path = [
             os.path.join(self.dcp.path, a) 
-            for a in allowed_foreign_files]
+            for a in self.allowed_foreign_files]
 
         self.dcp.foreign_files = [
             os.path.relpath(a, self.dcp.path)

--- a/clairmeta/dcp_check_global.py
+++ b/clairmeta/dcp_check_global.py
@@ -7,7 +7,7 @@ import six
 from clairmeta.dcp_utils import list_cpl_assets, cpl_probe_asset
 from clairmeta.dcp_check import CheckerBase
 from clairmeta.utils.sys import all_keys_in_dict
-from clairmeta.settings import DCP_CHECK_SETTINGS
+from clairmeta.profile import DCP_CHECK_PROFILE
 
 class Checker(CheckerBase):
     def __init__(self, dcp):
@@ -60,16 +60,16 @@ class Checker(CheckerBase):
         list_asset_path += self.dcp._list_vol_path
         list_asset_path += self.dcp._list_am_path
 
-        ignore_files = DCP_CHECK_SETTINGS['file_white_list']
+        allowed_foreign_files = DCP_CHECK_PROFILE['allowed_foreign_files']
 
-        ignore_files_path = [
+        allowed_foreign_files_path = [
             os.path.join(self.dcp.path, a) 
-            for a in ignore_files]
+            for a in allowed_foreign_files]
 
         self.dcp.foreign_files = [
             os.path.relpath(a, self.dcp.path)
             for a in self.dcp._list_files
-            if a not in list_asset_path and a not in ignore_files_path]
+            if a not in list_asset_path and a not in allowed_foreign_files_path]
         if self.dcp.foreign_files:
             self.error('\n'.join(self.dcp.foreign_files))
 

--- a/clairmeta/dcp_check_global.py
+++ b/clairmeta/dcp_check_global.py
@@ -7,7 +7,6 @@ import six
 from clairmeta.dcp_utils import list_cpl_assets, cpl_probe_asset
 from clairmeta.dcp_check import CheckerBase
 from clairmeta.utils.sys import all_keys_in_dict
-from clairmeta.profile import DCP_CHECK_PROFILE
 
 class Checker(CheckerBase):
     def __init__(self, dcp):

--- a/clairmeta/dcp_check_global.py
+++ b/clairmeta/dcp_check_global.py
@@ -7,7 +7,7 @@ import six
 from clairmeta.dcp_utils import list_cpl_assets, cpl_probe_asset
 from clairmeta.dcp_check import CheckerBase
 from clairmeta.utils.sys import all_keys_in_dict
-
+from clairmeta.settings import DCP_CHECK_SETTINGS
 
 class Checker(CheckerBase):
     def __init__(self, dcp):
@@ -60,10 +60,16 @@ class Checker(CheckerBase):
         list_asset_path += self.dcp._list_vol_path
         list_asset_path += self.dcp._list_am_path
 
+        ignore_files = DCP_CHECK_SETTINGS['file_white_list']
+
+        ignore_files_path = [
+            os.path.join(self.dcp.path, a) 
+            for a in ignore_files]
+
         self.dcp.foreign_files = [
             os.path.relpath(a, self.dcp.path)
             for a in self.dcp._list_files
-            if a not in list_asset_path]
+            if a not in list_asset_path and a not in ignore_files_path]
         if self.dcp.foreign_files:
             self.error('\n'.join(self.dcp.foreign_files))
 

--- a/clairmeta/profile.py
+++ b/clairmeta/profile.py
@@ -47,6 +47,10 @@ DCP_CHECK_PROFILE = {
     # Checker options
     # Bypass is a list of check names (function names)
     'bypass': [],
+
+    # Allowed foreign files
+    # Paths are relative to the DCP root
+    'allowed_foreign_files' : [],
 }
 
 

--- a/clairmeta/settings.py
+++ b/clairmeta/settings.py
@@ -163,7 +163,8 @@ DCP_CHECK_SETTINGS = {
         'sound': 'Sound essence checks',
         'subtitle': 'Subtitle essence checks',
         'atmos': 'Atmos essence checks',
-    }
+    },
+    'file_white_list': ['cs-md5.md5'],
 }
 
 IMP_SETTINGS = {

--- a/clairmeta/settings.py
+++ b/clairmeta/settings.py
@@ -163,8 +163,7 @@ DCP_CHECK_SETTINGS = {
         'sound': 'Sound essence checks',
         'subtitle': 'Subtitle essence checks',
         'atmos': 'Atmos essence checks',
-    },
-    'file_white_list': ['cs-md5.md5'],
+    }
 }
 
 IMP_SETTINGS = {


### PR DESCRIPTION
Even though I understand that DCP standards recommend no foreign file, for archival purposes, checksum files (eg: MD5 file) could be in the same folder as the DCP files and excluding certain files could be practical to still do the check of other foreign files.

This pull request is a very simple implementation that relies on a new setting in DCP_CHECK_SETTINGS.