### PR TITLE
Improve check diagnostic message and lower naming convention error level

### DIFF
--- a/clairmeta/dcp_check_execution.py
+++ b/clairmeta/dcp_check_execution.py
@@ -79,7 +79,7 @@ class CheckExecution(object):
 
     def short_desc(self):
         """Returns first line of the docstring or function name."""
-        docstring_lines = self.doc.split("\n")
+        docstring_lines = self.doc.split("\n") if self.doc else ""
         return docstring_lines[0].strip() if docstring_lines else self.name
 
     def is_valid(self, criticality="ERROR"):

--- a/clairmeta/profile.py
+++ b/clairmeta/profile.py
@@ -17,7 +17,7 @@ DCP_CHECK_PROFILE = {
     # 4 levels : ERROR, WARNING, INFO and SILENT.
     "criticality": {
         "default": "ERROR",
-        "check_dcnc_": "WARNING",
+        "check_dcnc_": "INFO",
         "check_dcp_foreign_files": "WARNING",
         "check_assets_am_volindex_one": "WARNING",
         "check_*_empty_text_fields": "WARNING",

--- a/clairmeta/report.py
+++ b/clairmeta/report.py
@@ -12,7 +12,15 @@ from clairmeta.utils.file import human_size
 class CheckReport(object):
     """Check report listing all checks executions."""
 
-    pretty_status = {
+    ORDERED_STATUS = [
+        "ERROR",
+        "WARNING",
+        "INFO",
+        "SILENT",
+        "BYPASS",
+    ]
+
+    PRETTY_STATUS = {
         "ERROR": "Error(s)",
         "WARNING": "Warning(s)",
         "INFO": "Info(s)",
@@ -109,20 +117,20 @@ class CheckReport(object):
         # Ignore silenced checks
         status_map.pop("SILENT", None)
 
-        for status, vals in six.iteritems(status_map):
+        for status in self.ORDERED_STATUS:
             out_stack = []
-            for k, v in six.iteritems(vals):
+            for k, v in six.iteritems(status_map[status]):
                 out_stack += [self._dump_stack("", k, v, indent_level=0)]
             if out_stack:
                 report += "{}\n{}\n".format(
-                    self.pretty_status[status] + ":", "\n".join(out_stack)
+                    self.PRETTY_STATUS[status] + ":", "\n".join(out_stack)
                 )
 
         bypassed = "\n".join(
             set(["  . " + c.short_desc() for c in self.checks_bypassed()])
         )
         if bypassed:
-            report += "{}\n{}\n".format(self.pretty_status["BYPASS"] + ":", bypassed)
+            report += "{}\n{}\n".format(self.PRETTY_STATUS["BYPASS"] + ":", bypassed)
 
         return report
 

--- a/tests/test_dcp_check.py
+++ b/tests/test_dcp_check.py
@@ -181,7 +181,8 @@ class DCPCheckReportTest(CheckerTestBase):
         self.report.errors_by_criticality("ERROR")
         self.assertEqual(3, len(self.report.checks_failed()))
         self.assertEqual(1, len(self.report.errors_by_criticality("ERROR")))
-        self.assertEqual(2, len(self.report.errors_by_criticality("WARNING")))
+        self.assertEqual(1, len(self.report.errors_by_criticality("WARNING")))
+        self.assertEqual(1, len(self.report.errors_by_criticality("INFO")))
 
         check = self.report.checks_by_criticality("ERROR")[0]
         self.assertEqual(check.name, "check_picture_cpl_max_bitrate")


### PR DESCRIPTION
This PR contains the following changes:
- Naming convention check now default to INFO instead WARNING following discussion in #235 
- Improve description and error reporting from `check_dcp_signed` as reported by @jamiegau 
- Make sure errors reported in the console output are always ordered from most to least severe