### PR TITLE
J2C validation from RDD 52 Compatibility Note 1

### DIFF
--- a/clairmeta/ext/note_1_validator_main/.gitignore
+++ b/clairmeta/ext/note_1_validator_main/.gitignore
@@ -1,0 +1,160 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/

--- a/clairmeta/ext/note_1_validator_main/LICENSE
+++ b/clairmeta/ext/note_1_validator_main/LICENSE
@@ -1,0 +1,24 @@
+BSD 2-Clause License
+
+Copyright (c) 2023, Sandflow Consulting
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/clairmeta/ext/note_1_validator_main/README.txt
+++ b/clairmeta/ext/note_1_validator_main/README.txt
@@ -1,0 +1,7 @@
+Pure Python script that validates JPEG 2000 codestreams against [Compatibility Note 1](https://github.com/SMPTE/rdd52/issues/8).
+
+To run:
+
+`python validate.py <J2C frame>`
+
+Work supported by [Kakadu Software](https://kakadusoftware.com/).

--- a/clairmeta/ext/note_1_validator_main/validate.py
+++ b/clairmeta/ext/note_1_validator_main/validate.py
@@ -1,0 +1,155 @@
+#!/usr/bin/python3
+
+import sys
+from enum import Enum
+import struct
+from itertools import islice
+import argparse
+
+class BadBytesException(Exception):
+  def __init__(self, offset) -> None:
+    self.offset = offset
+    super().__init__(f"0xFFFF detected at offset {offset}")
+
+class CodestreamException(Exception):
+  def __init__(self, msg) -> None:
+    super().__init__(msg)
+
+class Marker(Enum):
+  SOT = (0xFF90)
+  SOD = (0xFF93, True)
+  EPH = (0xFF92, True)
+  SOP = (0xFF91)
+  EOC = (0xFFD9, True)
+  SOC = (0xFF4F, True)
+  SIZ = (0xFF51)
+  COD = (0xff52)
+  QCD = (0xff5c)
+  POC = (0xff5f)
+  COM = (0xff64)
+  TLM = (0xff55)
+  COC = (0xff53)
+  PLT = (0xff58)
+  QCC = (0xff5d)
+  PLM = (0xff57)
+  CRG = (0xff63)
+
+  def __new__(cls, marker, is_empty = False):
+    obj = object.__new__(cls)
+    obj._value_ = marker
+    obj.is_empty = is_empty
+    return obj
+
+def read_byte(f, p):
+  f.seek(p)
+  v = f.read(1)
+  if len(v) != 1:
+    raise "Read error"
+  return v[0]
+
+def trigger_positions(main_header_len, tile_part_offset, tile_part_len):
+  for p in range(254, main_header_len + tile_part_len, 256):
+    yield (p if p < main_header_len else p - main_header_len + tile_part_offset,
+           p + 1 if p < main_header_len else p + 1 - main_header_len + tile_part_offset)
+
+def check_tile_part(f, main_header_len, tile_part_offset, tile_part_len):
+  for (p1, p2) in trigger_positions(main_header_len, tile_part_offset, tile_part_len):
+    if  read_byte(f, p1) == 0xFF and read_byte(f, p2) == 0xFF:
+      raise BadBytesException(p1)
+
+def validate(fn, isVerbose):
+  f = open(fn, "rb")
+
+  tile_parts_len = []
+  main_header_len = 0
+
+  while True:
+    marker_bytes = f.read(2)
+    if len(marker_bytes) != 2:
+      break
+
+    marker = Marker(marker_bytes[0] * 256 + marker_bytes[1])
+
+    if marker is Marker.SOT:
+      main_header_len = f.tell() - 2 # subtract the SOT marker length
+      break;
+
+    if marker.is_empty:
+      continue
+
+    size_field = f.read(2)
+    if len(size_field) != 2:
+      break
+    segment_size = ((size_field[0] << 8) + size_field[1])
+
+    if marker is not Marker.TLM:
+      # skip over the marker segment
+      f.seek(segment_size - 2, 1)
+      continue
+
+    if (isVerbose):
+      print(f"Found TLM marker segment af position {hex(f.tell() - 2)}")
+
+    if len(tile_parts_len) > 0:
+      if (isVerbose):
+        raise CodestreamException("Multiple TLM marker segments")
+
+    payload = f.read(segment_size - 2)
+
+    # stlm
+
+    st_field = (payload[1] & 0b00110000) >> 4
+    sp_field = (payload[1] & 0b01000000) >> 6
+
+    fmt = ">"
+
+    if st_field == 1:
+      fmt += "B"
+    elif st_field == 2:
+      fmt += "H"
+
+    if sp_field == 0:
+      fmt += "H"
+    else:
+      fmt += "L"
+
+    for entry in islice(struct.iter_unpack(fmt, payload[2:]), 3):
+      tile_parts_len.append(entry[-1])
+
+  if len(tile_parts_len) != 3:
+    raise CodestreamException("Missing or incomplete TLM marker segment")
+
+  if isVerbose:
+    print(f"Tile-part lengths: {', '.join(map(str, tile_parts_len))}")
+
+  if main_header_len <= 0:
+    raise CodestreamException("Invalid Main Header length")
+
+  if isVerbose:
+    print(f"Main header length: {main_header_len}")
+
+  # scan for the forbidden pattern
+
+  # main_header + tile_part_1
+
+  check_tile_part(f, main_header_len, main_header_len, tile_parts_len[0])
+
+  # main_header + tile_part_2
+
+  check_tile_part(f, main_header_len, main_header_len + tile_parts_len[0], tile_parts_len[1])
+
+  # main_header + tile_part_2
+
+  check_tile_part(f, main_header_len, main_header_len + tile_parts_len[0] + tile_parts_len[1], tile_parts_len[2])
+
+if __name__ == "__main__":
+  parser = argparse.ArgumentParser(description="Validate codestream against Compatibility Note 1")
+  parser.add_argument("-v", "--verbose", action="store_true", default=False, help="Print additional information about the codestream")
+  parser.add_argument("codestream", help="Path to the codestream to be validated")
+  args = parser.parse_args()
+
+  try:
+    validate(args.codestream, args.verbose)
+  except Exception as e:
+    sys.stderr.write(f"{e}\n")
+    sys.exit(1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,3 +29,9 @@ black = "^23.9.1"
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.black]
+extend-exclude = '''(clairmeta/ext/*)'''
+
+[tool.ruff]
+exclude = ["clairmeta/ext"]


### PR DESCRIPTION
Following discussion with @jamiegau and report from https://github.com/SMPTE/rdd52/issues/8, this PR adds an example implementation of the check from https://github.com/sandflow/note-1-validator (assuming the license allow us including the code but will not merge unless confirmed). As the issue is still under active research, not planning on merging this in the short term in any case. Note that to this will only work on unencrypted DCPs or encrypted DCP for which you provide both KDM and Private key to ClairMeta (which I don't expect to be possible for most cases).

Tagging @palemieux for visibility.