### PR TITLE
Validate certificate date against the IssueDate instead of current time

### DIFF
--- a/clairmeta/dcp_check_sign.py
+++ b/clairmeta/dcp_check_sign.py
@@ -376,10 +376,42 @@ class Checker(CheckerBase):
             not_before_str = cert.get_notBefore().decode("utf-8")
             not_before = datetime.strptime(not_before_str, time_format)
             not_after_str = cert.get_notAfter().decode("utf-8")
-            not_after = datetime.strptime(not_after_str, "%Y%m%d%H%M%SZ")
+            not_after = datetime.strptime(not_after_str, time_format)
 
             if validity_time < not_before or validity_time > not_after:
-                self.error("Certificate is not valid at this time")
+                self.error(
+                    "IssueDate ({}) outside certificate validity (from {} to {})".format(
+                        validity_time, not_before, not_after
+                    )
+                )
+
+    def check_certif_date_expired(self, cert, index):
+        """Certificate date expiration.
+
+        This is an informative note, when trying to play a CPL with an expired
+        certificate may fail on older / non-updated systems not compliant with
+        DCI specification 1.4.4.
+
+        References:
+            https://www.isdcf.com/certs-expiring/
+        """
+        # 9. Check time validity
+        # Note : Date are formatted in ASN.1 Time YYYYMMDDhhmmssZ
+        time_format = "%Y%m%d%H%M%SZ"
+        validity_time = datetime.now()
+
+        not_before_str = cert.get_notBefore().decode("utf-8")
+        not_before = datetime.strptime(not_before_str, time_format)
+        not_after_str = cert.get_notAfter().decode("utf-8")
+        not_after = datetime.strptime(not_after_str, time_format)
+
+        if validity_time < not_before or validity_time > not_after:
+            self.error(
+                "Certificate validity expired (from {} to {}).\n"
+                "Playback may fail on non DCI 1.4.4 compliant systems.".format(
+                    not_before, not_after
+                )
+            )
 
     def check_certif_date_overflow(self, cert, index):
         """Certificate date overflow check.

--- a/clairmeta/profile.py
+++ b/clairmeta/profile.py
@@ -29,6 +29,7 @@ DCP_CHECK_PROFILE = {
         "check_assets_cpl_labels_schema": "WARNING",
         "check_assets_cpl_filename_uuid": "WARNING",
         "check_certif_multi_role": "WARNING",
+        "check_certif_date_expired": "INFO",
         "check_certif_date_overflow": "WARNING",
         "check_picture_cpl_avg_bitrate": "WARNING",
         "check_picture_cpl_resolution": "WARNING",


### PR DESCRIPTION
From DCI Specifications 1.4.4:

> The CPL meets the two validation requirements defined in Section 5.2.1. of SMPTE 430-5 "D-Cinema Operations – Security Log Event Class and Constraints for D-Cinema" with the following caveat: When performing Step 9 of Section 6.2 in SMPTE ST 430-2, the desired time of the validation context shall be equal to the IssueDate field of the target CPL (and not the current time). This behavior permits the continued playback of a CPL after the expiration of its signing certificate, but ensures that the signing took place during the certificate's validity period.